### PR TITLE
Add initial version of a scenario parser

### DIFF
--- a/driver/parser/parser.go
+++ b/driver/parser/parser.go
@@ -1,0 +1,87 @@
+package parser
+
+import (
+	"bytes"
+	"io"
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Scenario is the root element of a scenario description. It defines basic
+// scenario properties and lists a set of nodes and transaction source.
+type Scenario struct {
+	Name    string
+	Nodes   []Node   `yaml:",omitempty"`
+	Sources []Source `yaml:",omitempty"`
+}
+
+// Node is a configuration for a group of nodes with similar properties.
+// Each node has a name, a set of features (e.g. 'validator', 'archve'),
+// and a start and end time. Furthermore, nodes may be instantiated multiple
+// times to create larger, homogenious groups easier.
+type Node struct {
+	Name      string
+	Features  []string
+	Instances *int     `yaml:",omitempty"` // nil is interpreted as 1
+	Start     *float32 `yaml:",omitempty"` // nil is interpreted as 0
+	End       *float32 `yaml:",omitempty"` // nil is interpreted as end-of-scenario
+}
+
+// Source is a load generator in the simulated network. Each source defines
+// a type application load is generated for, a start and end time, a traffic
+// shape (see Rate below), and a number of instances.
+type Source struct {
+	Application string
+	Instances   *int     `yaml:",omitempty"` // nil is interpreted as 1
+	Start       *float32 `yaml:",omitempty"` // nil is interpreted as 0
+	End         *float32 `yaml:",omitempty"` // nil is interpreted as end-of-scenario
+	Rate        Rate
+}
+
+// Rate defines the shape of traffic to be generated. There are three types
+// currently supported:
+//   - constant ... traffic is created at a constant rate
+//   - slope    ... traffic rate starts at 0 and is linearly increased
+//   - wave     ... traffic rate follows a sin-wave pattern
+//
+// Only one of those options can be set for a single source.
+type Rate struct {
+	// Only one of the next fields may be set.
+	Constant *int  `yaml:",omitempty"`
+	Slope    *int  `yaml:",omitempty"`
+	Wave     *Wave `yaml:",omitempty"`
+}
+
+// Wave defines the parameters of a sin-wave traffic pattern.
+type Wave struct {
+	Min    *int    `yaml:",omitempty"` // Tx/s, nil = 0
+	Max    int     // Tx/s
+	Period float32 // seconds
+}
+
+// Parse parses a YAML based scenario description from the given reader.
+// The parsing will fail if there are syntactic issues in the YAML file
+// or if there are unknown keys. However, no semantic checks on the resulting
+// scenariou will be conducted.
+func Parse(reader io.Reader) (Scenario, error) {
+	var res Scenario
+	decoder := yaml.NewDecoder(reader)
+	decoder.KnownFields(true)
+	err := decoder.Decode(&res)
+	return res, err
+}
+
+// ParseBytes parses the YAML encoded scenario in the given byte slice.
+func ParseBytes(data []byte) (Scenario, error) {
+	return Parse(bytes.NewReader(data))
+}
+
+// ParseFile parses the YAML encoded scenario in the given file.
+func ParseFile(path string) (Scenario, error) {
+	if reader, err := os.Open(path); err == nil {
+		return Parse(reader)
+	} else {
+		return Scenario{}, err
+	}
+}

--- a/driver/parser/parser_test.go
+++ b/driver/parser/parser_test.go
@@ -1,0 +1,78 @@
+package parser
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseEmpty(t *testing.T) {
+	_, err := ParseBytes([]byte{})
+	if err == nil {
+		t.Fatal("parsing of empty input should have failed")
+	}
+}
+
+var minimalExample = `
+name: Minimal Example
+`
+
+func TestParseMinimalExample(t *testing.T) {
+	_, err := ParseBytes([]byte(minimalExample))
+	if err != nil {
+		t.Fatalf("parsing of the minimal example should have worked, got %v", err)
+	}
+}
+
+var unknownKeyExample = minimalExample + `
+some_other_key: with a value
+`
+
+func TestParseFailsOnUnknownKey(t *testing.T) {
+	_, err := ParseBytes([]byte(unknownKeyExample))
+	if err == nil {
+		t.Fatalf("parsing of the example with unknown key should have failed")
+	}
+	if !strings.Contains(err.Error(), "some_other_key") {
+		t.Errorf("error message should have named the invalid key")
+	}
+}
+
+// smallExample defines a small scenario including instances of most
+// configuration options.
+var smallExample = `
+name: Small Test
+nodes:
+  - name: A
+    instances: 10
+    features:
+      - validator
+      - archive
+    start: 5
+    end: 7.5
+
+sources:
+  - application: lottery
+    instances: 10
+    start: 7
+    end: 10
+    rate:
+      constant: 8
+
+  - application: my_coin
+    rate:
+      slope: 10
+
+  - application: game
+    rate:
+      wave:
+        min: 10
+        max: 20
+        period: 120
+`
+
+func TestParseSmallExampleWorks(t *testing.T) {
+	_, err := ParseBytes([]byte(smallExample))
+	if err != nil {
+		t.Fatalf("parsing of input failed: %v", err)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,7 @@
+module github.com/Fantom-foundation/Norma
+
+go 1.19
+
+require (
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,3 @@
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
This PR introduces an initial version of a scenario configuration file parser. 

It adds types for the various entities in the definition file and handles basic syntactic errors. Semantic checks will follow.