### PR TITLE
Test go formatting in a standalone GH workflow

### DIFF
--- a/.github/workflows/go-linux.yml
+++ b/.github/workflows/go-linux.yml
@@ -27,10 +27,6 @@ jobs:
       with:
         go-version: '1.20'
 
-    - name: Check Go sources formatting
-      working-directory: ./
-      run: diff=`gofmt -s -d driver/.`; echo "$diff"; test -z "$diff"
-
     - name: Build Docker Image
       working-directory: ./
       run: docker build . -t opera

--- a/.github/workflows/go-osx.yml
+++ b/.github/workflows/go-osx.yml
@@ -32,10 +32,6 @@ jobs:
       with:
         version: v23.0.4
 
-    - name: Check Go sources formatting
-      working-directory: ./
-      run: diff=`gofmt -s -d driver/.`; echo "$diff"; test -z "$diff"
-
     - name: Build Docker Image
       working-directory: ./
       run: docker build . -t opera

--- a/.github/workflows/gofmt.yml
+++ b/.github/workflows/gofmt.yml
@@ -1,0 +1,25 @@
+name: Go-Formatting
+
+on:
+  push:
+    branches: [ "main" ]
+    paths:
+      - '.github/workflows/gofmt.yml'
+      - '**.go'
+  pull_request:
+    branches: [ "main" ]
+    paths:
+      - '.github/workflows/gofmt.yml'
+      - '**.go'
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Check Go sources formatting
+      working-directory: ./
+      run: diff=`gofmt -s -d .`; echo "$diff"; test -z "$diff"
+


### PR DESCRIPTION
This ensure all subdirs formatting will be checked, but it will still ignore go-opera files.