### PR TITLE
Disable OSX PR builds

### DIFF
--- a/.github/workflows/go-osx.yml
+++ b/.github/workflows/go-osx.yml
@@ -6,11 +6,6 @@ on:
     paths:
       - '.github/workflows/go-osx.yml'
       - '**.go'
-  pull_request:
-    branches: [ "main" ]
-    paths:
-      - '.github/workflows/go-osx.yml'
-      - '**.go'
 
 jobs:
 


### PR DESCRIPTION
This disables OSX builds for PRs. Keeps OSX builds for the main branch.