### PR TITLE
Add OperaNode managing a single network node instance

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,4 +28,7 @@ COPY --from=build /client/build/opera .
 ENV VALIDATOR_NUMBER=1
 ENV VALIDATORS_COUNT=1
 
-CMD ./opera --fakenet ${VALIDATOR_NUMBER}/${VALIDATORS_COUNT}
+EXPOSE 18545
+
+COPY scripts/run_opera.sh .
+CMD /bin/bash run_opera.sh

--- a/driver/node.go
+++ b/driver/node.go
@@ -7,6 +7,7 @@ package driver
 // interact with the node, and shut it down.
 type Node interface {
 	// GetNodeID returns an enode identifying this node within the Norma network.
+	// An error shall be produced if no valid node ID could be obtained.
 	GetNodeID() (NodeID, error)
 
 	// GetRpcServiceUrl returns the URL of the RPC server running on the

--- a/driver/node/opera.go
+++ b/driver/node/opera.go
@@ -1,0 +1,121 @@
+package node
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/Fantom-foundation/Norma/driver"
+	"github.com/Fantom-foundation/Norma/driver/docker"
+	"github.com/Fantom-foundation/Norma/driver/network"
+	"github.com/ethereum/go-ethereum/rpc"
+)
+
+const OperaRPCPort = 18545
+
+var OperaRpcService = network.ServiceDescription{
+	Name: "OperaRPC",
+	Port: OperaRPCPort,
+}
+
+const operaDockerImageName = "opera"
+
+// OperaNode implements the driver's Node interface by running a go-opera
+// client on a generic host.
+type OperaNode struct {
+	host network.Host
+}
+
+// StartOperaDockerNode creates a new OperaNode running in a Docker container.
+func StartOperaDockerNode(client *docker.Client, isValidator bool) (*OperaNode, error) {
+	timeout := 1 * time.Second
+
+	validatorFlag := "0"
+	if isValidator {
+		validatorFlag = "1"
+	}
+
+	operaServicePort, err := network.GetFreePort()
+	if err != nil {
+		return nil, err
+	}
+	host, err := client.Start(&docker.ContainerConfig{
+		ImageName:       operaDockerImageName,
+		ShutdownTimeout: &timeout,
+		PortForwarding: map[network.Port]network.Port{
+			OperaRPCPort: operaServicePort,
+		},
+		Environment: map[string]string{
+			"VALIDATOR_NUMBER": validatorFlag,
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+	node := &OperaNode{
+		host: host,
+	}
+
+	// Wait until the OperaNode inside the Container is ready.
+	for i := 0; i < 100; i++ {
+		_, err := node.GetNodeID()
+		if err == nil {
+			return node, nil
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	// The node did not show up in time, so we consider the start to have failed.
+	node.host.Cleanup()
+	return nil, fmt.Errorf("failed to get node online")
+}
+
+func (n *OperaNode) GetRpcServiceUrl() *driver.URL {
+	addr := n.host.GetAddressForService(&OperaRpcService)
+	if addr == nil {
+		return nil
+	}
+	url := driver.URL(fmt.Sprintf("http://%s", *addr))
+	return &url
+}
+
+func (n *OperaNode) GetNodeID() (driver.NodeID, error) {
+	url := n.GetRpcServiceUrl()
+	if url == nil {
+		return "", fmt.Errorf("node does not export an RPC server")
+	}
+	rpcClient, err := rpc.DialContext(context.Background(), string(*url))
+	if err != nil {
+		return "", err
+	}
+	var result struct {
+		Enode string
+	}
+	err = rpcClient.Call(&result, "admin_nodeInfo")
+	if err != nil {
+		return "", err
+	}
+	return driver.NodeID(result.Enode), nil
+}
+
+func (n *OperaNode) Stop() error {
+	return n.host.Stop()
+}
+
+func (n *OperaNode) Cleanup() error {
+	return n.host.Cleanup()
+}
+
+// AddPeer informs the client instance represented by the OperaNode about the
+// existence of another node, to which it may establish a connection.
+func (n *OperaNode) AddPeer(id driver.NodeID) error {
+	url := n.GetRpcServiceUrl()
+	if url == nil {
+		return fmt.Errorf("node does not export an RPC server")
+	}
+	rpcClient, err := rpc.DialContext(context.Background(), string(*url))
+	if err != nil {
+		return err
+	}
+	return rpcClient.Call(nil, "admin_addPeer", id)
+}

--- a/driver/node/opera_test.go
+++ b/driver/node/opera_test.go
@@ -1,0 +1,47 @@
+package node
+
+import (
+	"testing"
+
+	"github.com/Fantom-foundation/Norma/driver"
+	"github.com/Fantom-foundation/Norma/driver/docker"
+)
+
+func TestImplements(t *testing.T) {
+	var inst OperaNode
+	var _ driver.Node = &inst
+
+}
+
+func TestOperaNode_StartAndStop(t *testing.T) {
+	docker, err := docker.NewClient()
+	if err != nil {
+		t.Fatalf("failed to create a docker client: %v", err)
+	}
+	defer docker.Close()
+	node, err := StartOperaDockerNode(docker, false)
+	if err != nil {
+		t.Fatalf("failed to create an Opera node on Docker: %v", err)
+	}
+	if err = node.host.Stop(); err != nil {
+		t.Errorf("failed to stop Opera node: %v", err)
+	}
+}
+
+func TestOperaNode_RpcServiceIsReadyAfterStartup(t *testing.T) {
+	docker, err := docker.NewClient()
+	if err != nil {
+		t.Fatalf("failed to create a docker client: %v", err)
+	}
+	defer docker.Close()
+	node, err := StartOperaDockerNode(docker, false)
+	if err != nil {
+		t.Fatalf("failed to create an Opera node on Docker: %v", err)
+	}
+	if id, err := node.GetNodeID(); err != nil || len(id) == 0 {
+		t.Errorf("failed to fetch NodeID from Opera node: '%v', err: %v", id, err)
+	}
+	if err = node.host.Stop(); err != nil {
+		t.Errorf("failed to stop Opera node: %v", err)
+	}
+}

--- a/scripts/run_opera.sh
+++ b/scripts/run_opera.sh
@@ -1,0 +1,8 @@
+# Get the local node's IP.
+list=`hostname -I`
+array=($list)
+external_ip=${array[0]}
+echo "Opera is going to export its services on ${external_ip}"
+
+# Starting opera as part of a fake net with RPC service.
+./opera --fakenet ${VALIDATOR_NUMBER}/${VALIDATORS_COUNT} --http --http.addr 0.0.0.0 --http.api admin,eth,ftm --nat=extip:${external_ip}


### PR DESCRIPTION
This PR introduces an `OperaNode` type capable of running a `go-opera` client on an abstract host.