### PR TITLE
Add local network implementation and run command to Norma executable

### DIFF
--- a/driver/executor/executor_test.go
+++ b/driver/executor/executor_test.go
@@ -44,9 +44,11 @@ func TestExecutor_RunSingleNodeScenario(t *testing.T) {
 	node := driver.NewMockNode(ctrl)
 
 	// In this scenario, a node is expected to be created and shut down.
-	net.EXPECT().CreateNode(gomock.Any()).Return(node, nil)
-	node.EXPECT().Stop()
-	node.EXPECT().Cleanup()
+	gomock.InOrder(
+		net.EXPECT().CreateNode(gomock.Any()).Return(node, nil),
+		node.EXPECT().Stop(),
+		node.EXPECT().Cleanup(),
+	)
 
 	if err := Run(clock, net, &scenario); err != nil {
 		t.Errorf("failed to run scenario: %v", err)
@@ -77,12 +79,16 @@ func TestExecutor_RunMultipleNodeScenario(t *testing.T) {
 	node2 := driver.NewMockNode(ctrl)
 
 	// In this scenario, two nodes are created and stopped.
-	net.EXPECT().CreateNode(gomock.Any()).Return(node1, nil)
-	net.EXPECT().CreateNode(gomock.Any()).Return(node2, nil)
-	node1.EXPECT().Stop()
-	node1.EXPECT().Cleanup()
-	node2.EXPECT().Stop()
-	node2.EXPECT().Cleanup()
+	gomock.InOrder(
+		net.EXPECT().CreateNode(gomock.Any()).Return(node1, nil),
+		node1.EXPECT().Stop(),
+		node1.EXPECT().Cleanup(),
+	)
+	gomock.InOrder(
+		net.EXPECT().CreateNode(gomock.Any()).Return(node2, nil),
+		node2.EXPECT().Stop(),
+		node2.EXPECT().Cleanup(),
+	)
 
 	if err := Run(clock, net, &scenario); err != nil {
 		t.Errorf("failed to run scenario: %v", err)

--- a/driver/network/local/local.go
+++ b/driver/network/local/local.go
@@ -1,0 +1,126 @@
+package local
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"math/big"
+
+	"github.com/Fantom-foundation/Norma/driver"
+	"github.com/Fantom-foundation/Norma/driver/docker"
+	"github.com/Fantom-foundation/Norma/driver/node"
+	"github.com/Fantom-foundation/Norma/load/controller"
+	"github.com/Fantom-foundation/Norma/load/generator"
+	"github.com/Fantom-foundation/Norma/load/shaper"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/ethclient"
+)
+
+// LocalNetwork is a Docker based network running each individual node
+// within its own, dedicated Docker Container.
+type LocalNetwork struct {
+	docker  *docker.Client
+	nodes   map[driver.NodeID]*node.OperaNode
+	primary *node.OperaNode // first node generated, always the only validator for now
+}
+
+func NewLocalNetwork() (driver.Network, error) {
+	client, err := docker.NewClient()
+	if err != nil {
+		return nil, err
+	}
+	return &LocalNetwork{
+		docker: client,
+		nodes:  map[driver.NodeID]*node.OperaNode{},
+	}, nil
+}
+
+func (n *LocalNetwork) CreateNode(config *driver.NodeConfig) (driver.Node, error) {
+	// TODO: support more than one validator node
+	isValidator := len(n.nodes) == 0 // for now, only the first node is a validator
+	node, err := node.StartOperaDockerNode(n.docker, isValidator)
+	if err != nil {
+		return nil, err
+	}
+
+	id, err := node.GetNodeID()
+	for _, other := range n.nodes {
+		if err := other.AddPeer(id); err != nil {
+			return nil, err
+		}
+	}
+
+	if len(n.nodes) == 0 {
+		n.primary = node
+	}
+
+	n.nodes[id] = node
+	return node, err
+}
+
+// reasureAccountPrivateKey is an account with tokens that can be used to
+// initiate test applications and accounts.
+const treasureAccountPrivateKey = "163f5f0f9a621d72fedd85ffca3d08d131ab4e812181e0d30ffd1c885d20aac7" // Fakenet validator 1
+
+const fakeNetworkID = 0xfa3
+
+type localApplication struct {
+	controller *controller.AppController
+	cancel     context.CancelFunc
+}
+
+func (a *localApplication) Start() error {
+	ctx, cancel := context.WithCancel(context.Background())
+	a.cancel = cancel
+	go func() {
+		err := a.controller.Run(ctx)
+		if err != nil {
+			log.Printf("Failed to run load generator: %v", err)
+		}
+	}()
+	return nil
+}
+
+func (a *localApplication) Stop() error {
+	a.cancel()
+	return nil
+}
+
+func (n *LocalNetwork) CreateApplication(config *driver.ApplicationConfig) (driver.Application, error) {
+
+	if n.primary == nil {
+		return nil, fmt.Errorf("network is empty")
+	}
+
+	url := n.primary.GetRpcServiceUrl()
+	if url == nil {
+		return nil, fmt.Errorf("primary node is not running an RPC server")
+	}
+
+	rpcClient, err := ethclient.Dial(string(*url))
+	if err != nil {
+		return nil, err
+	}
+
+	privateKey, err := crypto.HexToECDSA(treasureAccountPrivateKey)
+	if err != nil {
+		return nil, err
+	}
+
+	counterGenerator, err := generator.NewCounterTransactionGenerator(privateKey, big.NewInt(fakeNetworkID))
+	if err != nil {
+		return nil, err
+	}
+
+	constantShaper := shaper.NewConstantShaper(config.Rate)
+
+	sourceDriver := controller.NewAppController(counterGenerator, constantShaper, rpcClient)
+	err = sourceDriver.Init()
+	if err != nil {
+		return nil, err
+	}
+
+	return &localApplication{
+		controller: sourceDriver,
+	}, nil
+}

--- a/driver/network/local/local_test.go
+++ b/driver/network/local/local_test.go
@@ -1,0 +1,92 @@
+package local
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/Fantom-foundation/Norma/driver"
+)
+
+func TestLocalNetworkIsNetwork(t *testing.T) {
+	var net LocalNetwork
+	var _ driver.Network = &net
+}
+
+func TestLocalNetwork_CanStartNodesAndShutThemDown(t *testing.T) {
+	for N := 1; N <= 3; N++ {
+		t.Run(fmt.Sprintf("num_nodes=%d", N), func(t *testing.T) {
+
+			net, err := NewLocalNetwork()
+			if err != nil {
+				t.Fatalf("failed to create new local network: %v", err)
+			}
+
+			nodes := []driver.Node{}
+			for i := 0; i < N; i++ {
+				node, err := net.CreateNode(&driver.NodeConfig{
+					Name: fmt.Sprintf("T-%d", i),
+				})
+				if err != nil {
+					t.Errorf("failed to create node: %v", err)
+				}
+				defer node.Cleanup()
+				nodes = append(nodes, node)
+			}
+
+			for _, node := range nodes {
+				if err := node.Stop(); err != nil {
+					t.Errorf("failed to stop node: %v", err)
+				}
+			}
+
+			for _, node := range nodes {
+				if err := node.Cleanup(); err != nil {
+					t.Errorf("failed to cleanup node: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestLocalNetwork_CanStartApplicatonsAndShutThemDown(t *testing.T) {
+	for N := 1; N <= 3; N++ {
+		t.Run(fmt.Sprintf("num_nodes=%d", N), func(t *testing.T) {
+
+			net, err := NewLocalNetwork()
+			if err != nil {
+				t.Fatalf("failed to create new local network: %v", err)
+			}
+
+			// We need at last one node running.
+			node, err := net.CreateNode(&driver.NodeConfig{})
+			if err != nil {
+				t.Fatalf("failed to create node in network: %v", err)
+			}
+			defer node.Cleanup()
+
+			apps := []driver.Application{}
+			for i := 0; i < N; i++ {
+				app, err := net.CreateApplication(&driver.ApplicationConfig{
+					Name: fmt.Sprintf("T-%d", i),
+				})
+				if err != nil {
+					t.Errorf("failed to create app: %v", err)
+				}
+				defer app.Stop()
+				apps = append(apps, app)
+			}
+
+			for _, app := range apps {
+				if err := app.Start(); err != nil {
+					t.Errorf("failed to start app: %v", err)
+				}
+			}
+
+			for _, app := range apps {
+				if err := app.Stop(); err != nil {
+					t.Errorf("failed to stop app: %v", err)
+				}
+			}
+		})
+	}
+}

--- a/driver/norma/main.go
+++ b/driver/norma/main.go
@@ -18,6 +18,7 @@ func main() {
 		Flags:     []cli.Flag{},
 		Commands: []*cli.Command{
 			&checkCommand,
+			&runCommand,
 		},
 	}
 	if err := app.Run(os.Args); err != nil {

--- a/driver/norma/run.go
+++ b/driver/norma/run.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/Fantom-foundation/Norma/driver/executor"
+	"github.com/Fantom-foundation/Norma/driver/network/local"
+	"github.com/Fantom-foundation/Norma/driver/parser"
+	"github.com/urfave/cli/v2"
+)
+
+// Run with `go run ./driver/norma run <scenario.yml>`
+
+var runCommand = cli.Command{
+	Action: run,
+	Name:   "run",
+	Usage:  "runs a scenario",
+}
+
+func run(ctx *cli.Context) (err error) {
+
+	args := ctx.Args()
+	if args.Len() < 1 {
+		return fmt.Errorf("requires scenario file as an argument")
+	}
+
+	path := args.First()
+	fmt.Printf("Running '%s' ...\n", path)
+
+	scenario, err := parser.ParseFile(path)
+	if err != nil {
+		return err
+	}
+
+	clock := executor.NewWallTimeClock()
+	net, err := local.NewLocalNetwork()
+	if err != nil {
+		return err
+	}
+
+	err = executor.Run(clock, net, &scenario)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("Execution completed successfully!\n")
+	return nil
+}


### PR DESCRIPTION
This PR adds
- a `LocalNetwork` implementation, using Docker-based Opera nodes to create test networks
- a `run` command to the `norma` executable to execute scenario files