### PR TITLE
Add abi generating into Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,15 @@ pull-hello-world-image:
 build-opera-docker-image:
 	docker build . -t opera
 
+generate-abi: load/contracts/abi/Counter.abi # requires installed solc and Ethereum abigen - check README.md
+
+load/contracts/abi/Counter.abi: load/contracts/Counter.sol
+	cd load/generator; solc -o ../contracts/abi --overwrite --pretty-json --optimize --abi --bin ../contracts/Counter.sol
+	abigen --type Counter --pkg abi --abi load/contracts/abi/Counter.abi --bin load/contracts/abi/Counter.bin --out load/contracts/abi/Counter.go
+
+generate-mocks: # requires installed mockgen
+	go generate ./...
+
 norma: build-opera-docker-image
 	go build -o $(BUILD_DIR)/norma ./driver/norma
 

--- a/README.md
+++ b/README.md
@@ -10,12 +10,14 @@ Project of integrating Carmen Storage and Tosca VM into go-opera.
 For building the project, the following tools are required:
 * Go: version 1.20 or later; we recommend to use your system's package manager; alternatively, you can follow Go's [installation manual](https://go.dev/doc/install) or; if you need to maintain multiple versions, [this tutorial](https://go.dev/doc/manage-install) describes how to do so
 * Docker: we recommend to use your system's package manager or the installation manuals listed in the [Using Docker](#using-docker) section below
-* GNU make, or comatible
+* GNU make, or compatible
 
-Optinally, before running `go generate ./...`, make sure you installed:
+Optionally, before running `make generate-mocks`, make sure you installed:
 * GoMock: `go install github.com/golang/mock/mockgen@v1.6.0`
   * Make sure `$GOPATH/bin` is in your `$PATH`. `$GOPATH` defaults to `$HOME/go` if not set, i.e. configure `$PATH` 
   * either to `PATH=$GOPATH/bin:$PATH` or `PATH=$HOME/go/bin:$PATH` 
+
+Optionally, before running `make generate-abi`, make sure you have installed:
 * Solidity Compiler (solc) - see [Installing the Solidity Compiler](https://docs.soliditylang.org/en/latest/installing-solidity.html)
   * Install version [0.8.19](https://github.com/ethereum/solidity/releases/tag/v0.8.19)
 * go-ethereum's abigen: 

--- a/load/generator/counter_generator.go
+++ b/load/generator/counter_generator.go
@@ -12,9 +12,6 @@ import (
 	"time"
 )
 
-//go:generate solc -o ../contracts/abi --overwrite --pretty-json --optimize --abi --bin ../contracts/Counter.sol
-//go:generate abigen --type Counter --pkg abi --abi ../contracts/abi/Counter.abi --bin ../contracts/abi/Counter.bin --out ../contracts/abi/Counter.go
-
 // CounterTransactionGenerator is a txs generator incrementing trivial Counter contract
 type CounterTransactionGenerator struct {
 	auth            *bind.TransactOpts


### PR DESCRIPTION
(Calling solc in "load/generator" ensure the generated binary is not changed by this.)

This allows to generate mocks using mockgen without dependency on ethereum/solidity tools -  they are needed only for new make target "generate-abi".