### PR TITLE
Add support for stopping scenario runs using Ctrl+c

### DIFF
--- a/driver/docker/docker_test.go
+++ b/driver/docker/docker_test.go
@@ -27,6 +27,26 @@ func TestRunAndStopOneContainer(t *testing.T) {
 	}
 }
 
+func TestContainer_StopCanBeCalledMoreThanOnce(t *testing.T) {
+	_, cont := startContainer(t)
+
+	if !cont.IsRunning() {
+		t.Errorf("started container is not running")
+	}
+
+	if err := cont.Stop(); err != nil {
+		t.Fatalf("error stopping container: %v", err)
+	}
+
+	if cont.IsRunning() {
+		t.Errorf("stopped container is still running")
+	}
+
+	if err := cont.Stop(); err != nil {
+		t.Fatalf("error calling Stop() on stopped container: %v", err)
+	}
+}
+
 func TestContainer_Cleanup(t *testing.T) {
 	cli, cont := startContainer(t)
 
@@ -36,6 +56,30 @@ func TestContainer_Cleanup(t *testing.T) {
 
 	if containerExists(t, cli, cont.id) {
 		t.Errorf("container should not exist: %s", cont.id)
+	}
+}
+
+func TestContainer_CleanupCanBeCalledMoreThanOnce(t *testing.T) {
+	cli, cont := startContainer(t)
+
+	if !cont.IsRunning() {
+		t.Errorf("started container is not running")
+	}
+
+	if err := cont.Cleanup(); err != nil {
+		t.Fatalf("error cleaning up container: %v", err)
+	}
+
+	if containerExists(t, cli, cont.id) {
+		t.Errorf("container should no longer exist: %s", cont.id)
+	}
+
+	if cont.IsRunning() {
+		t.Errorf("cleaned up container is still running")
+	}
+
+	if err := cont.Cleanup(); err != nil {
+		t.Fatalf("error calling Cleanup() on cleared container: %v", err)
 	}
 }
 

--- a/driver/executor/clock_test.go
+++ b/driver/executor/clock_test.go
@@ -35,17 +35,46 @@ func TestClock_SleepSkipsTimeAccurately(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			clock := test.clock
 			start := clock.Now()
-			duration := Seconds(0.5)
-			clock.SleepUntil(duration)
+			time := Seconds(0.5)
+			clock.SleepUntil(time)
 			end := clock.Now()
 
-			offset := end - (start + duration)
+			offset := end - (start + time)
 			if offset < Milliseconds(-10) {
 				t.Errorf("sleep did not suspend execution long enough, offset: %v", offset)
 			}
 
 			if offset > Milliseconds(10) {
 				t.Errorf("slept too long, offset: %v", offset)
+			}
+		})
+	}
+}
+
+func TestClock_NotifyAtSkipsTimeAccurately(t *testing.T) {
+	for _, test := range getClocks() {
+		t.Run(test.name, func(t *testing.T) {
+			clock := test.clock
+			start := clock.Now()
+			time := Seconds(0.5)
+			weakUpTime := <-clock.NotifyAt(time)
+			end := clock.Now()
+
+			offset := end - (start + time)
+			if offset < Milliseconds(-10) {
+				t.Errorf("sleep did not suspend execution long enough, offset: %v", offset)
+			}
+
+			if offset > Milliseconds(10) {
+				t.Errorf("slept too long, offset: %v", offset)
+			}
+
+			offset = end - weakUpTime
+			if offset < 0 {
+				t.Errorf("weak-up time received through notification is not consistent with clock")
+			}
+			if offset > Milliseconds(1) {
+				t.Errorf("delay between weak-up time and clock time is to high: %v", offset)
 			}
 		})
 	}

--- a/driver/network.go
+++ b/driver/network.go
@@ -15,6 +15,10 @@ type Network interface {
 	// CreateApplication creates a new application in this network, ready to
 	// produce load as defined by its configuration.
 	CreateApplication(config *ApplicationConfig) (Application, error)
+
+	// Shutdown stops all applications and nodes in the network and frees
+	// any potential other resources.
+	Shutdown() error
 }
 
 type NodeConfig struct {

--- a/driver/network/local/local_test.go
+++ b/driver/network/local/local_test.go
@@ -90,3 +90,34 @@ func TestLocalNetwork_CanStartApplicatonsAndShutThemDown(t *testing.T) {
 		})
 	}
 }
+
+func TestLocalNetwork_CanPerformNetworkShutdown(t *testing.T) {
+	N := 2
+
+	net, err := NewLocalNetwork()
+	if err != nil {
+		t.Fatalf("failed to create new local network: %v", err)
+	}
+
+	for i := 0; i < N; i++ {
+		_, err := net.CreateNode(&driver.NodeConfig{
+			Name: fmt.Sprintf("T-%d", i),
+		})
+		if err != nil {
+			t.Errorf("failed to create node: %v", err)
+		}
+	}
+
+	for i := 0; i < N; i++ {
+		_, err := net.CreateApplication(&driver.ApplicationConfig{
+			Name: fmt.Sprintf("T-%d", i),
+		})
+		if err != nil {
+			t.Errorf("failed to create app: %v", err)
+		}
+	}
+
+	if err := net.Shutdown(); err != nil {
+		t.Errorf("failed to shut down network: %v", err)
+	}
+}

--- a/driver/network_mock.go
+++ b/driver/network_mock.go
@@ -62,3 +62,17 @@ func (mr *MockNetworkMockRecorder) CreateNode(config interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateNode", reflect.TypeOf((*MockNetwork)(nil).CreateNode), config)
 }
+
+// Shutdown mocks base method.
+func (m *MockNetwork) Shutdown() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Shutdown")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Shutdown indicates an expected call of Shutdown.
+func (mr *MockNetworkMockRecorder) Shutdown() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Shutdown", reflect.TypeOf((*MockNetwork)(nil).Shutdown))
+}

--- a/driver/norma/run.go
+++ b/driver/norma/run.go
@@ -25,23 +25,32 @@ func run(ctx *cli.Context) (err error) {
 	}
 
 	path := args.First()
-	fmt.Printf("Running '%s' ...\n", path)
-
+	fmt.Printf("Reading '%s' ...\n", path)
 	scenario, err := parser.ParseFile(path)
 	if err != nil {
 		return err
 	}
 
 	clock := executor.NewWallTimeClock()
+
+	fmt.Printf("Createing network ...\n")
 	net, err := local.NewLocalNetwork()
 	if err != nil {
 		return err
 	}
+	defer func() {
+		fmt.Printf("Shutting down network ...\n")
+		if err := net.Shutdown(); err != nil {
+			fmt.Printf("error during network shutdown:\n%v", err)
+		}
+	}()
 
+	fmt.Printf("Running '%s' ...\n", path)
 	err = executor.Run(clock, net, &scenario)
 	if err != nil {
 		return err
 	}
 	fmt.Printf("Execution completed successfully!\n")
+
 	return nil
 }


### PR DESCRIPTION
With this change, executions of `norma run` can be aborted using `Ctrl+c` while still performing a clean shutdown.