### PR TITLE
Add support for configurable number of validators

### DIFF
--- a/driver/network.go
+++ b/driver/network.go
@@ -21,6 +21,13 @@ type Network interface {
 	Shutdown() error
 }
 
+// NetworkConfig is a collection of network parameters to be used by factories
+// creating network instances.
+type NetworkConfig struct {
+	// NumberOfValidators is the (static) number of validators in the network.
+	NumberOfValidators int
+}
+
 type NodeConfig struct {
 	Name string
 	// TODO: add other parameters as needed

--- a/driver/node/opera_test.go
+++ b/driver/node/opera_test.go
@@ -19,7 +19,9 @@ func TestOperaNode_StartAndStop(t *testing.T) {
 		t.Fatalf("failed to create a docker client: %v", err)
 	}
 	defer docker.Close()
-	node, err := StartOperaDockerNode(docker, false)
+	node, err := StartOperaDockerNode(docker, &OperaNodeConfig{
+		NetworkConfig: &driver.NetworkConfig{NumberOfValidators: 1},
+	})
 	if err != nil {
 		t.Fatalf("failed to create an Opera node on Docker: %v", err)
 	}
@@ -34,7 +36,9 @@ func TestOperaNode_RpcServiceIsReadyAfterStartup(t *testing.T) {
 		t.Fatalf("failed to create a docker client: %v", err)
 	}
 	defer docker.Close()
-	node, err := StartOperaDockerNode(docker, false)
+	node, err := StartOperaDockerNode(docker, &OperaNodeConfig{
+		NetworkConfig: &driver.NetworkConfig{NumberOfValidators: 1},
+	})
 	if err != nil {
 		t.Fatalf("failed to create an Opera node on Docker: %v", err)
 	}

--- a/driver/norma/run.go
+++ b/driver/norma/run.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 
+	"github.com/Fantom-foundation/Norma/driver"
 	"github.com/Fantom-foundation/Norma/driver/executor"
 	"github.com/Fantom-foundation/Norma/driver/network/local"
 	"github.com/Fantom-foundation/Norma/driver/parser"
@@ -33,8 +34,14 @@ func run(ctx *cli.Context) (err error) {
 
 	clock := executor.NewWallTimeClock()
 
-	fmt.Printf("Createing network ...\n")
-	net, err := local.NewLocalNetwork()
+	netConfig := driver.NetworkConfig{
+		NumberOfValidators: 1,
+	}
+	if scenario.NumValidators != nil {
+		netConfig.NumberOfValidators = *scenario.NumValidators
+	}
+	fmt.Printf("Createing network with %d validator(s) ...\n", netConfig.NumberOfValidators)
+	net, err := local.NewLocalNetwork(&netConfig)
 	if err != nil {
 		return err
 	}

--- a/driver/parser/check.go
+++ b/driver/parser/check.go
@@ -15,6 +15,9 @@ func (s *Scenario) Check() error {
 	if s.Duration <= 0 {
 		errs = append(errs, fmt.Errorf("scenario duration must be > 0"))
 	}
+	if s.NumValidators != nil && *s.NumValidators <= 0 {
+		errs = append(errs, fmt.Errorf("invalid number of validators: %d <= 0", *s.NumValidators))
+	}
 	for _, node := range s.Nodes {
 		if err := node.Check(s); err != nil {
 			errs = append(errs, err)

--- a/driver/parser/check_test.go
+++ b/driver/parser/check_test.go
@@ -286,6 +286,15 @@ func TestScenario_NegativeDurationIsDetected(t *testing.T) {
 	}
 }
 
+func TestScenario_NegativeNumberOfValidatorsIsDetected(t *testing.T) {
+	scenario := Scenario{Name: "Test"}
+	scenario.NumValidators = new(int)
+	*scenario.NumValidators = -5
+	if err := scenario.Check(); err == nil || !strings.Contains(err.Error(), "invalid number of validators: -5 <= 0") {
+		t.Errorf("neagative number of validators was not detected")
+	}
+}
+
 func TestScenario_NodeIssuesAreDetected(t *testing.T) {
 	scenario := Scenario{
 		Name:     "Test",

--- a/driver/parser/parser.go
+++ b/driver/parser/parser.go
@@ -11,10 +11,11 @@ import (
 // Scenario is the root element of a scenario description. It defines basic
 // scenario properties and lists a set of nodes and transaction source.
 type Scenario struct {
-	Name         string
-	Duration     float32
-	Nodes        []Node        `yaml:",omitempty"`
-	Applications []Application `yaml:",omitempty"`
+	Name          string
+	Duration      float32
+	NumValidators *int          `yaml:"num_validators,omitempty"` // nil == 1
+	Nodes         []Node        `yaml:",omitempty"`
+	Applications  []Application `yaml:",omitempty"`
 }
 
 // Node is a configuration for a group of nodes with similar properties.

--- a/driver/parser/parser_test.go
+++ b/driver/parser/parser_test.go
@@ -41,6 +41,7 @@ func TestParseFailsOnUnknownKey(t *testing.T) {
 // configuration options.
 var smallExample = `
 name: Small Test
+num_validators: 5
 nodes:
   - name: A
     instances: 10

--- a/load/generator/counter_generator.go
+++ b/load/generator/counter_generator.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"crypto/ecdsa"
 	"fmt"
+	"math/big"
+	"time"
+
 	"github.com/Fantom-foundation/Norma/load/contracts/abi"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethclient"
-	"math/big"
-	"time"
 )
 
 // CounterTransactionGenerator is a txs generator incrementing trivial Counter contract
@@ -42,7 +43,7 @@ func (cg *CounterTransactionGenerator) Init(rpcClient *ethclient.Client) (err er
 }
 
 func waitUntilContractStartExisting(contractAddress common.Address, rpcClient *ethclient.Client) error {
-	for i := 0; i < 10; i++ {
+	for i := 0; i < 150; i++ {
 		time.Sleep(100 * time.Millisecond)
 		code, err := rpcClient.CodeAt(context.Background(), contractAddress, nil)
 		if err != nil {

--- a/scenarios/no_load.yml
+++ b/scenarios/no_load.yml
@@ -5,5 +5,4 @@ duration: 60    # seconds
 
 nodes:
   - name: A
-    features: [validator]
     instances: 3

--- a/scenarios/small.yml
+++ b/scenarios/small.yml
@@ -7,12 +7,14 @@ name: Small Network
 # The duration of the scenario's runtime, in seconds.
 duration: 60
 
+# The number of validator nodes in the network.
+num_validators: 1
+
 # The network scenario to exercise. 
 nodes:
-  # We include three validator nodes for the full duration.
+  # We include three additional non-validator nodes for the full duration.
   - name: A
     instances: 3
-    features: [ validator ]
 
 # In the network there is a single application producing constant load.
 applications:


### PR DESCRIPTION
This PR adds support for a configurable number of validators to the Norma scenario configuration options. 

The configured number of validators is static during the runtime. Thus, all validators are created during network startup and stopped during the network shutdown.