### PR TITLE
Use the global NodeID type also in the monitoring package

### DIFF
--- a/driver/monitoring/monitor_test.go
+++ b/driver/monitoring/monitor_test.go
@@ -18,8 +18,8 @@ func TestMonitor_RegisterAndRetrievalOfDataWorks(t *testing.T) {
 	seriesB := &TestBlockSeries{[]int{3, 4, 5}}
 
 	source := TestSource{}
-	source.setData(Node(1), seriesA)
-	source.setData(Node(2), seriesB)
+	source.setData(Node("A"), seriesA)
+	source.setData(Node("B"), seriesB)
 
 	metric := source.GetMetric()
 
@@ -38,20 +38,20 @@ func TestMonitor_RegisterAndRetrievalOfDataWorks(t *testing.T) {
 		t.Errorf("registered metric is not supported")
 	}
 
-	want := []Node{Node(1), Node(2)}
+	want := []Node{Node("A"), Node("B")}
 	if got := GetSubjects(monitor, metric); !slices.Equal(want, got) {
 		t.Errorf("invalid list of subjects, wanted %v, got %v", want, got)
 	}
 
-	if *GetData(monitor, Node(1), metric) != seriesA {
+	if *GetData(monitor, Node("A"), metric) != seriesA {
 		t.Errorf("obtained wrong data for node 1")
 	}
 
-	if *GetData(monitor, Node(2), metric) != seriesB {
+	if *GetData(monitor, Node("B"), metric) != seriesB {
 		t.Errorf("obtained wrong data for node 2")
 	}
 
-	if GetData(monitor, Node(3), metric) != nil {
+	if GetData(monitor, Node("C"), metric) != nil {
 		t.Errorf("should not have obtained any data for node 3")
 	}
 

--- a/driver/monitoring/source_test.go
+++ b/driver/monitoring/source_test.go
@@ -69,13 +69,13 @@ func TestTestSource_ListsCorrectSubjects(t *testing.T) {
 	if got := source.GetSubjects(); !slices.Equal(got, want) {
 		t.Errorf("invalid subject list, wanted %v, got %v", want, got)
 	}
-	source.setData(Node(1), &TestBlockSeries{[]int{1, 2, 3}})
-	want = []Node{Node(1)}
+	source.setData(Node("A"), &TestBlockSeries{[]int{1, 2, 3}})
+	want = []Node{Node("A")}
 	if got := source.GetSubjects(); !slices.Equal(got, want) {
 		t.Errorf("invalid subject list, wanted %v, got %v", want, got)
 	}
-	source.setData(Node(2), &TestBlockSeries{[]int{1}})
-	want = []Node{Node(1), Node(2)}
+	source.setData(Node("B"), &TestBlockSeries{[]int{1}})
+	want = []Node{Node("A"), Node("B")}
 	if got := source.GetSubjects(); !slices.Equal(got, want) {
 		t.Errorf("invalid subject list, wanted %v, got %v", want, got)
 	}
@@ -86,16 +86,16 @@ func TestTestSource_RetrievesCorrectDataSeries(t *testing.T) {
 	seriesB := &TestBlockSeries{[]int{3, 4, 5}}
 
 	source := TestSource{}
-	source.setData(Node(1), seriesA)
-	source.setData(Node(2), seriesB)
+	source.setData(Node("A"), seriesA)
+	source.setData(Node("B"), seriesB)
 
-	if *source.GetData(Node(1)) != seriesA {
+	if *source.GetData(Node("A")) != seriesA {
 		t.Errorf("test source returned wrong series")
 	}
-	if *source.GetData(Node(2)) != seriesB {
+	if *source.GetData(Node("B")) != seriesB {
 		t.Errorf("test source returned wrong series")
 	}
-	if source.GetData(Node(3)) != nil {
+	if source.GetData(Node("C")) != nil {
 		t.Errorf("test source returned wrong series")
 	}
 }

--- a/driver/monitoring/types.go
+++ b/driver/monitoring/types.go
@@ -1,9 +1,13 @@
 package monitoring
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/Fantom-foundation/Norma/driver"
+)
 
 // Node identifies a node in the network.
-type Node int
+type Node driver.NodeID
 
 // BlockNumber is the type used to identify a block.
 type BlockNumber int


### PR DESCRIPTION
This eliminates the need for maintaining a mapping between monitoring `Node` identifiers and `driver.NodeID`s.