### PR TITLE
Integrate monitoring into norma run executable

### DIFF
--- a/driver/monitoring/series.go
+++ b/driver/monitoring/series.go
@@ -13,7 +13,12 @@ type DataPoint[K constraints.Ordered, T any] struct {
 // Series is a generic interface for arbitrarily indexed sequences of values.
 // The type K is the index type, the type T the value associated to the keys.
 type Series[K constraints.Ordered, T any] interface {
+	// GetRange captures a snapshot of all points collected for the half-open
+	// interval [from,to).
 	GetRange(from, to K) []DataPoint[K, T]
+	// GetLatest retrieves the latest collected data point or nil if no data
+	// was collected.
+	GetLatest() *DataPoint[K, T]
 }
 
 // TimeSeries is a data Series using time-stamps as the index type.

--- a/driver/monitoring/series_test.go
+++ b/driver/monitoring/series_test.go
@@ -24,6 +24,14 @@ func (s *TestBlockSeries) GetRange(from, to BlockNumber) []DataPoint[BlockNumber
 	return res
 }
 
+func (s *TestBlockSeries) GetLatest() *DataPoint[BlockNumber, int] {
+	if len(s.data) == 0 {
+		return nil
+	}
+	pos := len(s.data) - 1
+	return &DataPoint[BlockNumber, int]{BlockNumber(pos), s.data[pos]}
+}
+
 func (s *TestBlockSeries) SetData(data []int) {
 	s.data = make([]int, len(data))
 	copy(s.data[:], data[:])

--- a/driver/monitoring/synced_series.go
+++ b/driver/monitoring/synced_series.go
@@ -36,6 +36,17 @@ func (s *SyncedSeries[K, T]) GetRange(from, to K) []DataPoint[K, T] {
 	return res
 }
 
+// GetLatest returns the latest collected data point in this series.
+func (s *SyncedSeries[K, T]) GetLatest() *DataPoint[K, T] {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	if len(s.data) == 0 {
+		return nil
+	}
+	res := s.data[len(s.data)-1]
+	return &res
+}
+
 // Append adds new data to the end of the series. The operation fails if the
 // provided point is <= the last added point.
 func (s *SyncedSeries[K, T]) Append(point K, value T) error {

--- a/driver/monitoring/synced_series_test.go
+++ b/driver/monitoring/synced_series_test.go
@@ -53,3 +53,31 @@ func TestSyncedSeries_AppendFailsIfTimeIsNotProgressing(t *testing.T) {
 		t.Errorf("error appending data point: %v", err)
 	}
 }
+
+func TestSyncedSeries_GetLatestReturnsLastAppendedValue(t *testing.T) {
+	series := SyncedSeries[Time, int]{}
+
+	db := func(t, v int) DataPoint[Time, int] {
+		return DataPoint[Time, int]{Time(t), v}
+	}
+
+	if got := series.GetLatest(); got != nil {
+		t.Errorf("last element should initially be nil")
+	}
+
+	if err := series.Append(Time(0), 12); err != nil {
+		t.Errorf("error appending data point: %v", err)
+	}
+
+	if got, want := series.GetLatest(), db(0, 12); got == nil || *got != want {
+		t.Errorf("latest element not as expected, wanted %d, got %d", got, want)
+	}
+
+	if err := series.Append(Time(2), 8); err != nil {
+		t.Errorf("error appending data point: %v", err)
+	}
+
+	if got, want := series.GetLatest(), db(2, 8); got == nil || *got != want {
+		t.Errorf("latest element not as expected, wanted %d, got %d", got, want)
+	}
+}

--- a/driver/norma/run.go
+++ b/driver/norma/run.go
@@ -2,9 +2,15 @@ package main
 
 import (
 	"fmt"
+	"log"
+	"sort"
+	"time"
 
 	"github.com/Fantom-foundation/Norma/driver"
 	"github.com/Fantom-foundation/Norma/driver/executor"
+	"github.com/Fantom-foundation/Norma/driver/monitoring"
+	netmon "github.com/Fantom-foundation/Norma/driver/monitoring/network"
+	nodemon "github.com/Fantom-foundation/Norma/driver/monitoring/node"
 	"github.com/Fantom-foundation/Norma/driver/network/local"
 	"github.com/Fantom-foundation/Norma/driver/parser"
 	"github.com/urfave/cli/v2"
@@ -34,13 +40,24 @@ func run(ctx *cli.Context) (err error) {
 
 	clock := executor.NewWallTimeClock()
 
+	// Initialize monitoring environment.
+	monitor := monitoring.NewMonitor()
+	defer func() {
+		// TODO: dump data before shutting down monitor
+		fmt.Printf("Shutting down data monitor ...\n")
+		if err := monitor.Shutdown(); err != nil {
+			fmt.Printf("error during monitor shutdown:\n%v", err)
+		}
+	}()
+
+	// Startup network.
 	netConfig := driver.NetworkConfig{
 		NumberOfValidators: 1,
 	}
 	if scenario.NumValidators != nil {
 		netConfig.NumberOfValidators = *scenario.NumValidators
 	}
-	fmt.Printf("Createing network with %d validator(s) ...\n", netConfig.NumberOfValidators)
+	fmt.Printf("Creating network with %d validator(s) ...\n", netConfig.NumberOfValidators)
 	net, err := local.NewLocalNetwork(&netConfig)
 	if err != nil {
 		return err
@@ -52,7 +69,15 @@ func run(ctx *cli.Context) (err error) {
 		}
 	}()
 
+	// Install monitoring sensory.
+	if err := setupMonitoringSources(monitor, net); err != nil {
+		return err
+	}
+
+	// Run scenario.
 	fmt.Printf("Running '%s' ...\n", path)
+	logger := startProgressLogger(monitor)
+	defer logger.shutdown()
 	err = executor.Run(clock, net, &scenario)
 	if err != nil {
 		return err
@@ -60,4 +85,86 @@ func run(ctx *cli.Context) (err error) {
 	fmt.Printf("Execution completed successfully!\n")
 
 	return nil
+}
+
+func setupMonitoringSources(monitor *monitoring.Monitor, network driver.Network) error {
+	// TODO: create some registry for sources factories
+	monitoring.RegisterSource(monitor, netmon.NewNumNodesSource(network))
+	monitoring.RegisterSource(monitor, nodemon.NewNodeBlockHeightSource(network))
+	return nil
+}
+
+type progressLogger struct {
+	monitor *monitoring.Monitor
+	stop    chan<- bool
+	done    <-chan bool
+}
+
+func startProgressLogger(monitor *monitoring.Monitor) *progressLogger {
+	stop := make(chan bool)
+	done := make(chan bool)
+
+	go func() {
+		defer close(done)
+		ticker := time.NewTicker(time.Second)
+		for {
+			select {
+			case <-stop:
+				return
+			case <-ticker.C:
+				logState(monitor)
+			}
+		}
+	}()
+
+	return &progressLogger{
+		monitor,
+		stop,
+		done,
+	}
+}
+
+func (l *progressLogger) shutdown() {
+	close(l.stop)
+	<-l.done
+}
+
+func logState(monitor *monitoring.Monitor) {
+	numNodes := getNumNodes(monitor)
+	blockHeights := getBlockHeights(monitor)
+	log.Printf("Block height of %s nodes in the network: %v", numNodes, blockHeights)
+}
+
+func getNumNodes(monitor *monitoring.Monitor) string {
+	data := monitoring.GetData(monitor, monitoring.Network{}, netmon.NumberOfNodes)
+	if data == nil {
+		return "N/A"
+	}
+	point := (*data).GetLatest()
+	if point == nil {
+		return "N/A"
+	}
+	return fmt.Sprintf("%d", point.Value)
+}
+
+func getBlockHeights(monitor *monitoring.Monitor) []string {
+	metric := nodemon.NodeBlockHeight
+	nodes := monitoring.GetSubjects(monitor, metric)
+	sort.Slice(nodes, func(i, j int) bool { return nodes[i] < nodes[j] })
+
+	res := make([]string, 0, len(nodes))
+	for _, node := range nodes {
+		data := monitoring.GetData(monitor, node, metric)
+		if data == nil {
+			res = append(res, "N/A")
+			continue
+		}
+		point := (*data).GetLatest()
+		if point == nil {
+			res = append(res, "N/A")
+			continue
+		}
+		res = append(res, fmt.Sprintf("%d", point.Value))
+	}
+	return res
 }


### PR DESCRIPTION
This PR integrates the monitoring system into Norma's `run` command.

It currently just uses the monitoring infrastructure for logging the block height of the various nodes in the network to the console. Future extensions may add the dumping of all collected data into files for post-processing.