### PR TITLE
allows for streaming logs of a host

### DIFF
--- a/driver/docker/docker.go
+++ b/driver/docker/docker.go
@@ -127,10 +127,10 @@ func (c *Container) Cleanup() error {
 // Container and being exported to the Docker's host environment. If there is
 // no such service (e.g., because it was not marked as to be exported during
 // the Start of the Container), nil will be returned.
-func (n *Container) GetAddressForService(service *network.ServiceDescription) *network.AddressPort {
+func (c *Container) GetAddressForService(service *network.ServiceDescription) *network.AddressPort {
 	// All services inside the container are reached through port-forwarding
 	// on the localhost. Non-forwarded services are not supported.
-	port, ok := n.config.PortForwarding[service.Port]
+	port, ok := c.config.PortForwarding[service.Port]
 	if !ok {
 		return nil
 	}
@@ -163,6 +163,21 @@ func (c *Container) SaveLogTo(directory string) error {
 	}
 
 	return nil
+}
+
+func (c *Container) StreamLog() (io.ReadCloser, error) {
+	opt := types.ContainerLogsOptions{
+		ShowStdout: true,
+		ShowStderr: true,
+		Follow:     true,
+	}
+
+	reader, err := c.client.cli.ContainerLogs(context.Background(), c.id, opt)
+	if err != nil {
+		return nil, err
+	}
+
+	return reader, nil
 }
 
 func (c *Client) listContainers() ([]types.Container, error) {

--- a/driver/network/host.go
+++ b/driver/network/host.go
@@ -1,5 +1,7 @@
 package network
 
+import "io"
+
 //go:generate mockgen -source host.go -destination host_mock.go -package network
 
 // AddressPort is a string addressing an IP and a port in the format <IP>:<port>.
@@ -24,6 +26,16 @@ type Host interface {
 
 	// SaveLogTo transfers the logs of the host to the given file directory.
 	SaveLogTo(directory string) error
+
+	// StreamLog provides a reader that is continuously providing the host log.
+	// The log is tailed via the reader and blocked until next log lines are ready.
+	// Before tailing new log lines, the reader can provide certain amount of previous log lines.
+	// For instance, the docker host uses a ring memory of 150 lines to buffer previous lines.
+	// The reader should reach its end (EOF) only when the host/container is stopped or interrupted.
+	// If this method is called many times, it should dispatch the log to all returned
+	// readers, i.e. all of them see the same output.
+	// It is up to the caller to close the stream.
+	StreamLog() (io.ReadCloser, error)
 
 	// Cleanup releases all underlying resources. After the cleanup no more
 	// operations on this host are expected to succeed.

--- a/driver/network/host_mock.go
+++ b/driver/network/host_mock.go
@@ -5,6 +5,7 @@
 package network
 
 import (
+	io "io"
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
@@ -101,4 +102,19 @@ func (m *MockHost) Stop() error {
 func (mr *MockHostMockRecorder) Stop() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stop", reflect.TypeOf((*MockHost)(nil).Stop))
+}
+
+// StreamLog mocks base method.
+func (m *MockHost) StreamLog() (io.ReadCloser, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "StreamLog")
+	ret0, _ := ret[0].(io.ReadCloser)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// StreamLog indicates an expected call of StreamLog.
+func (mr *MockHostMockRecorder) StreamLog() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StreamLog", reflect.TypeOf((*MockHost)(nil).StreamLog))
 }

--- a/driver/node.go
+++ b/driver/node.go
@@ -1,5 +1,7 @@
 package driver
 
+import "io"
+
 //go:generate mockgen -source node.go -destination node_mock.go -package driver
 
 // Node is controlling a single node in a Norma network. It provides abstract
@@ -16,6 +18,10 @@ type Node interface {
 	// GetRpcServiceUrl returns the URL of the RPC server running on the
 	// represented node. May be nil if no such service is offered.
 	GetRpcServiceUrl() *URL
+
+	// StreamLog provides a reader that is continuously providing the host log.
+	// It is up to the caller to close the stream.
+	StreamLog() (io.ReadCloser, error)
 
 	// Stop shuts down this node gracefully, using its regular shutdown
 	// procedure (not killed). After stopping the service, no more interactions

--- a/driver/node/opera.go
+++ b/driver/node/opera.go
@@ -3,6 +3,7 @@ package node
 import (
 	"context"
 	"fmt"
+	"io"
 	"time"
 
 	"github.com/Fantom-foundation/Norma/driver"
@@ -108,6 +109,10 @@ func (n *OperaNode) GetNodeID() (driver.NodeID, error) {
 		return "", err
 	}
 	return driver.NodeID(result.Enode), nil
+}
+
+func (n *OperaNode) StreamLog() (io.ReadCloser, error) {
+	return n.host.StreamLog()
 }
 
 func (n *OperaNode) Stop() error {

--- a/driver/node_mock.go
+++ b/driver/node_mock.go
@@ -5,6 +5,7 @@
 package driver
 
 import (
+	io "io"
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
@@ -102,4 +103,19 @@ func (m *MockNode) Stop() error {
 func (mr *MockNodeMockRecorder) Stop() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stop", reflect.TypeOf((*MockNode)(nil).Stop))
+}
+
+// StreamLog mocks base method.
+func (m *MockNode) StreamLog() (io.ReadCloser, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "StreamLog")
+	ret0, _ := ret[0].(io.ReadCloser)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// StreamLog indicates an expected call of StreamLog.
+func (mr *MockNodeMockRecorder) StreamLog() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StreamLog", reflect.TypeOf((*MockNode)(nil).StreamLog))
 }


### PR DESCRIPTION
This PR adds a method to get a stream log, i.e. the Reader from the (docker) host and node