### PR TITLE
Add function to fetch a CPU profile from a node

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,7 @@ COPY --from=build /client/build/opera .
 ENV VALIDATOR_NUMBER=1
 ENV VALIDATORS_COUNT=1
 
+EXPOSE 6060
 EXPOSE 18545
 
 COPY scripts/run_opera.sh .

--- a/driver/monitoring/node/block_progress.go
+++ b/driver/monitoring/node/block_progress.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/Fantom-foundation/Norma/driver"
 	mon "github.com/Fantom-foundation/Norma/driver/monitoring"
+	opera "github.com/Fantom-foundation/Norma/driver/node"
 	"github.com/ethereum/go-ethereum/rpc"
 )
 
@@ -68,7 +69,7 @@ func startCollector(node driver.Node, period time.Duration, stop <-chan bool, do
 			done <- err
 		}()
 
-		url := node.GetRpcServiceUrl()
+		url := node.GetHttpServiceUrl(&opera.OperaRpcService)
 		if url == nil {
 			err = fmt.Errorf("node does not export an RPC server")
 			return

--- a/driver/monitoring/node/block_progress_test.go
+++ b/driver/monitoring/node/block_progress_test.go
@@ -40,9 +40,9 @@ func TestNodeBlockHeightSourceRetrievesBlockHeight(t *testing.T) {
 	node2.EXPECT().GetNodeID().AnyTimes().Return(node2Id, nil)
 	node3.EXPECT().GetNodeID().AnyTimes().Return(node3Id, nil)
 
-	node1.EXPECT().GetRpcServiceUrl().AnyTimes().Return(&url)
-	node2.EXPECT().GetRpcServiceUrl().AnyTimes().Return(&url)
-	node3.EXPECT().GetRpcServiceUrl().AnyTimes().Return(&url)
+	node1.EXPECT().GetHttpServiceUrl(gomock.Any()).AnyTimes().Return(&url)
+	node2.EXPECT().GetHttpServiceUrl(gomock.Any()).AnyTimes().Return(&url)
+	node3.EXPECT().GetHttpServiceUrl(gomock.Any()).AnyTimes().Return(&url)
 
 	net.EXPECT().RegisterListener(gomock.Any())
 	net.EXPECT().UnregisterListener(gomock.Any())

--- a/driver/monitoring/node/cpu_profile.go
+++ b/driver/monitoring/node/cpu_profile.go
@@ -1,0 +1,29 @@
+package nodemon
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/Fantom-foundation/Norma/driver"
+	opera "github.com/Fantom-foundation/Norma/driver/node"
+)
+
+type PprofData []byte
+
+func GetPprofData(node driver.Node, duration time.Duration) (PprofData, error) {
+	url := node.GetHttpServiceUrl(&opera.OperaPprofService)
+	if url == nil {
+		return nil, fmt.Errorf("node does not offer the pprof service")
+	}
+	resp, err := http.Get(fmt.Sprintf("%s/debug/pprof/profile?seconds=%d", *url, int(duration.Seconds())))
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to fetch result: %v", resp)
+	}
+	return io.ReadAll(resp.Body)
+}

--- a/driver/monitoring/node/cpu_profile_test.go
+++ b/driver/monitoring/node/cpu_profile_test.go
@@ -1,0 +1,33 @@
+package nodemon
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Fantom-foundation/Norma/driver"
+	"github.com/Fantom-foundation/Norma/driver/docker"
+	opera "github.com/Fantom-foundation/Norma/driver/node"
+)
+
+func TestCanCollectCpuProfileDateFromOperaNode(t *testing.T) {
+	docker, err := docker.NewClient()
+	if err != nil {
+		t.Fatalf("failed to create a docker client: %v", err)
+	}
+	defer docker.Close()
+	node, err := opera.StartOperaDockerNode(docker, &opera.OperaNodeConfig{
+		NetworkConfig: &driver.NetworkConfig{NumberOfValidators: 1},
+	})
+	if err != nil {
+		t.Fatalf("failed to create an Opera node on Docker: %v", err)
+	}
+	defer node.Cleanup()
+
+	data, err := GetPprofData(node, time.Second)
+	if err != nil {
+		t.Errorf("failed to collect pprof data from node: %v", err)
+	}
+	if len(data) == 0 {
+		t.Errorf("fetched empty CPU profile")
+	}
+}

--- a/driver/network/local/local.go
+++ b/driver/network/local/local.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Fantom-foundation/Norma/driver"
 	"github.com/Fantom-foundation/Norma/driver/docker"
 	"github.com/Fantom-foundation/Norma/driver/node"
+	opera "github.com/Fantom-foundation/Norma/driver/node"
 	"github.com/Fantom-foundation/Norma/load/controller"
 	"github.com/Fantom-foundation/Norma/load/generator"
 	"github.com/Fantom-foundation/Norma/load/shaper"
@@ -167,7 +168,7 @@ func (n *LocalNetwork) CreateApplication(config *driver.ApplicationConfig) (driv
 		return nil, err
 	}
 
-	url := node.GetRpcServiceUrl()
+	url := node.GetHttpServiceUrl(&opera.OperaRpcService)
 	if url == nil {
 		return nil, fmt.Errorf("primary node is not running an RPC server")
 	}

--- a/driver/network/service_test.go
+++ b/driver/network/service_test.go
@@ -17,3 +17,20 @@ func TestGetFreePort(t *testing.T) {
 	}
 	listener.Close()
 }
+
+func TestGetFreePorts(t *testing.T) {
+	ports, err := GetFreePorts(5)
+	if err != nil {
+		t.Errorf("failed to obtain a free ports: %v", err)
+	}
+	if got, want := len(ports), 5; got != want {
+		t.Errorf("invalid number of ports obtained, got %d, wanted %d", got, want)
+	}
+	for _, port := range ports {
+		listener, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
+		if err != nil {
+			t.Errorf("provided port %d is not free", port)
+		}
+		defer listener.Close()
+	}
+}

--- a/driver/node.go
+++ b/driver/node.go
@@ -1,6 +1,10 @@
 package driver
 
-import "io"
+import (
+	"io"
+
+	"github.com/Fantom-foundation/Norma/driver/network"
+)
 
 //go:generate mockgen -source node.go -destination node_mock.go -package driver
 
@@ -15,9 +19,9 @@ type Node interface {
 	// An error shall be produced if no valid node ID could be obtained.
 	GetNodeID() (NodeID, error)
 
-	// GetRpcServiceUrl returns the URL of the RPC server running on the
+	// GetHttpServiceUrl returns the URL of a HTTP service running on the
 	// represented node. May be nil if no such service is offered.
-	GetRpcServiceUrl() *URL
+	GetHttpServiceUrl(*network.ServiceDescription) *URL
 
 	// StreamLog provides a reader that is continuously providing the host log.
 	// It is up to the caller to close the stream.

--- a/driver/node_mock.go
+++ b/driver/node_mock.go
@@ -8,6 +8,7 @@ import (
 	io "io"
 	reflect "reflect"
 
+	network "github.com/Fantom-foundation/Norma/driver/network"
 	gomock "github.com/golang/mock/gomock"
 )
 
@@ -48,6 +49,20 @@ func (mr *MockNodeMockRecorder) Cleanup() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Cleanup", reflect.TypeOf((*MockNode)(nil).Cleanup))
 }
 
+// GetHttpServiceUrl mocks base method.
+func (m *MockNode) GetHttpServiceUrl(arg0 *network.ServiceDescription) *URL {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetHttpServiceUrl", arg0)
+	ret0, _ := ret[0].(*URL)
+	return ret0
+}
+
+// GetHttpServiceUrl indicates an expected call of GetHttpServiceUrl.
+func (mr *MockNodeMockRecorder) GetHttpServiceUrl(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHttpServiceUrl", reflect.TypeOf((*MockNode)(nil).GetHttpServiceUrl), arg0)
+}
+
 // GetNodeID mocks base method.
 func (m *MockNode) GetNodeID() (NodeID, error) {
 	m.ctrl.T.Helper()
@@ -61,20 +76,6 @@ func (m *MockNode) GetNodeID() (NodeID, error) {
 func (mr *MockNodeMockRecorder) GetNodeID() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNodeID", reflect.TypeOf((*MockNode)(nil).GetNodeID))
-}
-
-// GetRpcServiceUrl mocks base method.
-func (m *MockNode) GetRpcServiceUrl() *URL {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetRpcServiceUrl")
-	ret0, _ := ret[0].(*URL)
-	return ret0
-}
-
-// GetRpcServiceUrl indicates an expected call of GetRpcServiceUrl.
-func (mr *MockNodeMockRecorder) GetRpcServiceUrl() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRpcServiceUrl", reflect.TypeOf((*MockNode)(nil).GetRpcServiceUrl))
 }
 
 // IsRunning mocks base method.

--- a/scripts/run_opera.sh
+++ b/scripts/run_opera.sh
@@ -5,4 +5,4 @@ external_ip=${array[0]}
 echo "Opera is going to export its services on ${external_ip}"
 
 # Starting opera as part of a fake net with RPC service.
-./opera --fakenet ${VALIDATOR_NUMBER}/${VALIDATORS_COUNT} --http --http.addr 0.0.0.0 --http.api admin,eth,ftm --nat=extip:${external_ip}
+./opera --fakenet ${VALIDATOR_NUMBER}/${VALIDATORS_COUNT} --http --http.addr 0.0.0.0 --http.api admin,eth,ftm --nat=extip:${external_ip} --pprof --pprof.addr 0.0.0.0


### PR DESCRIPTION
This PR introduces a utility function to fetch a CPU profile from a node within the network.

So far, this only covers the fetch method. A follow-up will add integration into the driver's run command.