### PR TITLE
integrates log based metrics into run of the experiments

### DIFF
--- a/driver/monitoring/monitor.go
+++ b/driver/monitoring/monitor.go
@@ -17,13 +17,14 @@ import (
 // methods in Go. Thus, several methods interacting with Monitor instances
 // are free functions (see implementations below).
 type Monitor struct {
-	network driver.Network
-	sources map[string]source
+	network         driver.Network
+	nodeLogProvider NodeLogProvider
+	sources         map[string]source
 }
 
 // NewMonitor creates a new Monitor instance without any registered sources.
 func NewMonitor(network driver.Network) *Monitor {
-	return &Monitor{network, map[string]source{}}
+	return &Monitor{network, NewNodeLogDispatcher(network), map[string]source{}}
 }
 
 // Shutdown disconnects all sources, stopping the collection of data. This
@@ -47,7 +48,7 @@ func InstallSource[S any, T any](monitor *Monitor, factory SourceFactory[S, T]) 
 	if present {
 		return fmt.Errorf("source for metric %s already present", metric.Name)
 	}
-	monitor.sources[metric.Name] = factory.CreateSource(monitor.network)
+	monitor.sources[metric.Name] = factory.CreateSource(monitor)
 	return nil
 }
 

--- a/driver/monitoring/network/block_metrics_test.go
+++ b/driver/monitoring/network/block_metrics_test.go
@@ -92,7 +92,7 @@ func testNetworkSeriesData[T comparable](t *testing.T, expectedBlocks []monitori
 	for _, want := range expectedBlocks {
 		var found bool
 		for i := 0; i < 100; i++ {
-			series := source.GetData(network)
+			series := *source.GetData(network)
 			for _, got := range series.GetRange(monitoring.BlockNumber(0), monitoring.BlockNumber(1000)) {
 				if source.getBlockProperty(want) == got.Value {
 					found = true
@@ -111,7 +111,7 @@ func testNetworkSeriesData[T comparable](t *testing.T, expectedBlocks []monitori
 	}
 
 	// check the size of the series matches the expected blocks
-	if got, want := len(source.GetData(network).GetRange(monitoring.BlockNumber(0), monitoring.BlockNumber(1000))), len(expectedBlocks); got != want {
+	if got, want := len((*source.GetData(network)).GetRange(monitoring.BlockNumber(0), monitoring.BlockNumber(1000))), len(expectedBlocks); got != want {
 		t.Errorf("block series lengths do not match")
 	}
 }
@@ -139,7 +139,7 @@ func testNetworkSource[T comparable](t *testing.T, source *BlockNetworkMetricSou
 
 	// table check results
 	for _, network := range source.GetSubjects() {
-		for _, block := range source.GetData(network).GetRange(monitoring.BlockNumber(0), monitoring.BlockNumber(1000)) {
+		for _, block := range (*source.GetData(network)).GetRange(monitoring.BlockNumber(0), monitoring.BlockNumber(1000)) {
 			if got, want := block.Value, source.getBlockProperty(monitoring.BlockchainTestData[block.Position-1]); got != want {
 				t.Errorf("data series contain unexpected value: %v != %v", got, want)
 			}

--- a/driver/monitoring/network/num_nodes.go
+++ b/driver/monitoring/network/num_nodes.go
@@ -16,7 +16,7 @@ var NumberOfNodes = mon.Metric[mon.Network, mon.TimeSeries[int]]{
 }
 
 func init() {
-	if err := mon.RegisterSource(NumberOfNodes, NewNumNodesSource); err != nil {
+	if err := mon.RegisterSource(NumberOfNodes, mon.AdaptNetworkToMonitorFactory(NewNumNodesSource)); err != nil {
 		panic(fmt.Sprintf("failed to register metric source: %v", err))
 	}
 }

--- a/driver/monitoring/node/block_metrics_test.go
+++ b/driver/monitoring/node/block_metrics_test.go
@@ -100,7 +100,7 @@ func testNodeSeriesData[T comparable](t *testing.T, node monitoring.Node, expect
 		for i := 0; i < 100; i++ {
 			series := source.GetData(node)
 			if series != nil {
-				for _, got := range series.GetRange(monitoring.BlockNumber(0), monitoring.BlockNumber(1000)) {
+				for _, got := range (*series).GetRange(monitoring.BlockNumber(0), monitoring.BlockNumber(1000)) {
 					if source.getBlockProperty(want) == got.Value {
 						found = true
 						break
@@ -119,7 +119,7 @@ func testNodeSeriesData[T comparable](t *testing.T, node monitoring.Node, expect
 	}
 
 	// check the size of the series matches the expected blocks
-	if got, want := len(source.GetData(node).GetRange(monitoring.BlockNumber(0), monitoring.BlockNumber(1000))), len(expectedBlocks); got != want {
+	if got, want := len((*source.GetData(node)).GetRange(monitoring.BlockNumber(0), monitoring.BlockNumber(1000))), len(expectedBlocks); got != want {
 		t.Errorf("block series do not match")
 	}
 }
@@ -148,7 +148,7 @@ func testNodeSource[T comparable](t *testing.T, source *BlockNodeMetricSource[T]
 
 	// table check results in each series for every node
 	for _, node := range source.GetSubjects() {
-		for _, block := range source.GetData(node).GetRange(monitoring.BlockNumber(0), monitoring.BlockNumber(1000)) {
+		for _, block := range (*source.GetData(node)).GetRange(monitoring.BlockNumber(0), monitoring.BlockNumber(1000)) {
 			if got, want := block.Value, source.getBlockProperty(monitoring.NodeBlockTestData[node][block.Position-1]); got != want {
 				t.Errorf("data series contain unexpected value: %v != %v", got, want)
 			}

--- a/driver/monitoring/node/block_progress.go
+++ b/driver/monitoring/node/block_progress.go
@@ -20,7 +20,7 @@ var NodeBlockHeight = mon.Metric[mon.Node, mon.TimeSeries[int]]{
 }
 
 func init() {
-	if err := mon.RegisterSource(NodeBlockHeight, NewNodeBlockHeightSource); err != nil {
+	if err := mon.RegisterSource(NodeBlockHeight, mon.AdaptNetworkToMonitorFactory(NewNodeBlockHeightSource)); err != nil {
 		panic(fmt.Sprintf("failed to register metric source: %v", err))
 	}
 }

--- a/driver/monitoring/node/cpu_profile.go
+++ b/driver/monitoring/node/cpu_profile.go
@@ -36,13 +36,13 @@ var NodeCpuProfile = mon.Metric[mon.Node, mon.TimeSeries[PprofData]]{
 }
 
 func init() {
-	if err := mon.RegisterSource(NodeCpuProfile, NewNodeCpuProfileSource); err != nil {
+	if err := mon.RegisterSource(NodeCpuProfile, mon.AdaptNetworkToMonitorFactory(NewNodeCpuProfileSource)); err != nil {
 		panic(fmt.Sprintf("failed to register metric source: %v", err))
 	}
 }
 
 // NewNodeCpuProfileSource creates a new data source periodically collecting
-// collecting CPU profiling data at configured sampling periods.
+// CPU profiling data at configured sampling periods.
 func NewNodeCpuProfileSource(network driver.Network) mon.Source[mon.Node, mon.TimeSeries[PprofData]] {
 	return newPeriodicNodeDataSource[PprofData](
 		NodeCpuProfile,


### PR DESCRIPTION
This PR adds the metrics parsed from Opera Log into the monitoring infrastructure. It prints `txs` and `gasUsed` to demonstrate it works 