### PR TITLE
tracks block processing time as a metric and print it to run

### DIFF
--- a/driver/monitoring/logreader.go
+++ b/driver/monitoring/logreader.go
@@ -11,10 +11,11 @@ import (
 )
 
 var (
-	timestampReg = regexp.MustCompile(`\[\S*\]`)
-	blockReg     = regexp.MustCompile(`index=\d*`)
-	gasReg       = regexp.MustCompile(`gas_used=\S*`)
-	txsReg       = regexp.MustCompile(`txs=\d+`)
+	timestampReg      = regexp.MustCompile(`\[\S*\]`)
+	blockReg          = regexp.MustCompile(`index=\d*`)
+	gasReg            = regexp.MustCompile(`gas_used=\S*`)
+	txsReg            = regexp.MustCompile(`txs=\d+`)
+	processingTimeReg = regexp.MustCompile(`t=\S*`)
 )
 
 // NewLogReader creates a channel and reads logs from the input reader, sending it to the channel.
@@ -64,11 +65,11 @@ func parseTime(str string) (time.Time, error) {
 // parseBlock parses block information from the log line. It is expected the log line is well-formed.
 func parseBlock(line string) (block Block, err error) {
 	// example line: "INFO [05-04|09:34:15.537] New block index=3 id=3:1:3d6fb6 gas_used=117,867 txs=1/0 age=343.255ms t=1.579ms
-
 	timestampStr := timestampReg.FindString(line)
 	blockNumberStr := strings.Split(blockReg.FindString(line), "=")[1]
 	gasUsedStr := strings.ReplaceAll(strings.Split(gasReg.FindString(line), "=")[1], ",", "")
 	txsStr := strings.Split(txsReg.FindString(line), "=")[1]
+	processingTimeStr := strings.Trim(strings.Split(processingTimeReg.FindString(line), "=")[1], "\"")
 
 	blockNumber, err := strconv.Atoi(blockNumberStr)
 	if err != nil {
@@ -90,18 +91,25 @@ func parseBlock(line string) (block Block, err error) {
 		return block, err
 	}
 
+	processingTime, err := time.ParseDuration(processingTimeStr)
+	if err != nil {
+		return block, err
+	}
+
 	return Block{
-		Height:  blockNumber,
-		Txs:     txs,
-		GasUsed: gasUsed,
-		Time:    timestamp,
+		Height:         blockNumber,
+		Txs:            txs,
+		GasUsed:        gasUsed,
+		Time:           timestamp,
+		ProcessingTime: processingTime,
 	}, nil
 }
 
 // Block contains data of one block
 type Block struct {
-	Height  int
-	Time    time.Time // timestamp of the block
-	Txs     int       // number of transactions in block
-	GasUsed int       // gas used in the block
+	Height         int
+	Time           time.Time     // timestamp of the block
+	Txs            int           // number of transactions in block
+	GasUsed        int           // gas used in the block
+	ProcessingTime time.Duration // block processing time
 }

--- a/driver/monitoring/node/block_metrics_test.go
+++ b/driver/monitoring/node/block_metrics_test.go
@@ -17,9 +17,11 @@ func TestCaptureSeriesFromNodeBlocksNodeMetrics(t *testing.T) {
 	producer.EXPECT().RegisterLogListener(gomock.Any()).AnyTimes()
 
 	source1 := NewBlockTimeSource(producer)
+	source2 := NewBlockProcessingTimeSource(producer)
 
 	// simulate data received to metric
 	testNodeSource(t, source1)
+	testNodeSource(t, source2)
 }
 
 func TestIntegrateRegistryWithShutdownNodeMetrics(t *testing.T) {

--- a/driver/monitoring/testdata.go
+++ b/driver/monitoring/testdata.go
@@ -7,7 +7,7 @@ var (
 	Node2TestId = Node("B")
 	Node3TestId = Node("C")
 
-	Node1TestLog = "INFO [05-04|09:34:15.080] New block      index=1 id=2:1:247c79       gas_used=11 txs=10/0 age=7.392s t=3.686ms \n" +
+	Node1TestLog = "INFO [05-04|09:34:15.080] New block      index=1 id=2:1:247c79       gas_used=11 txs=10/0 age=7.392s t=\"711.334µs\" \n" +
 		"INFO [05-04|09:34:15.537] New block      index=2 id=3:1:3d6fb6       gas_used=22 txs=20/0 age=343.255ms t=1.579ms \n" +
 		"INFO [05-04|09:34:16.027] New block      index=3 id=3:4:9bb789       gas_used=33   txs=30/0 age=380.470ms t=1.540ms \n"
 
@@ -23,19 +23,32 @@ var (
 	time5, _ = time.Parse("[01-02|15:04:05.000]", "[05-04|09:34:17.003]")
 	time6, _ = time.Parse("[01-02|15:04:05.000]", "[05-04|09:38:15.080]")
 
-	block1 = Block{Height: 1, Time: time1, Txs: 10, GasUsed: 11}
-	block2 = Block{Height: 2, Time: time2, Txs: 20, GasUsed: 22}
-	block3 = Block{Height: 3, Time: time3, Txs: 30, GasUsed: 33}
+	dur1, _ = time.ParseDuration("711.334µs")
+	dur2, _ = time.ParseDuration("1.579ms")
+	dur3, _ = time.ParseDuration("1.540ms")
+	dur4, _ = time.ParseDuration("4.686ms")
+	dur5, _ = time.ParseDuration("2.579ms")
+	dur6, _ = time.ParseDuration("5.686ms")
 
-	block4 = Block{Height: 1, Time: time4, Txs: 10, GasUsed: 11}
-	block5 = Block{Height: 2, Time: time5, Txs: 20, GasUsed: 22}
+	block1 = Block{Height: 1, Time: time1, Txs: 10, GasUsed: 11, ProcessingTime: dur1}
+	block2 = Block{Height: 2, Time: time2, Txs: 20, GasUsed: 22, ProcessingTime: dur2}
+	block3 = Block{Height: 3, Time: time3, Txs: 30, GasUsed: 33, ProcessingTime: dur3}
 
-	block6 = Block{Height: 1, Time: time6, Txs: 10, GasUsed: 11}
+	block4 = Block{Height: 1, Time: time4, Txs: 10, GasUsed: 11, ProcessingTime: dur4}
+	block5 = Block{Height: 2, Time: time5, Txs: 20, GasUsed: 22, ProcessingTime: dur5}
+
+	block6 = Block{Height: 1, Time: time6, Txs: 10, GasUsed: 11, ProcessingTime: dur6}
 
 	NodeBlockTestData = map[Node][]Block{
 		Node1TestId: {block1, block2, block3},
 		Node2TestId: {block4, block5},
 		Node3TestId: {block6},
+	}
+
+	BlockHeight1TestMap = map[int]Block{
+		1: block1,
+		2: block2,
+		3: block3,
 	}
 
 	BlockchainTestData = []Block{block1, block2, block3}


### PR DESCRIPTION
This PR extends metrics obtained from the log of the time processing time. It prints this metric at the progress log as well