### PR TITLE
uses comma exists idiom to check GetData returns data of a Source

### DIFF
--- a/driver/monitoring/monitor.go
+++ b/driver/monitoring/monitor.go
@@ -69,10 +69,10 @@ func GetSubjects[S any, T any](monitor *Monitor, metric Metric[S, T]) []S {
 
 // GetData retrieves access to the data collected for a given metric or nil, if
 // the defined metric for the given subject is not available.
-func GetData[S any, T any](monitor *Monitor, subject S, metric Metric[S, T]) *T {
+func GetData[S any, T any](monitor *Monitor, subject S, metric Metric[S, T]) (t T, exists bool) {
 	source := monitor.sources[metric.Name]
 	if source == nil {
-		return nil
+		return t, false
 	}
 	return source.(Source[S, T]).GetData(subject)
 }

--- a/driver/monitoring/monitor_test.go
+++ b/driver/monitoring/monitor_test.go
@@ -61,15 +61,15 @@ func TestMonitor_RegisterAndRetrievalOfDataWorks(t *testing.T) {
 		t.Errorf("invalid list of subjects, wanted %v, got %v", want, got)
 	}
 
-	if *GetData(monitor, Node("A"), metric) != seriesA {
+	if series, exists := GetData(monitor, Node("A"), metric); !exists || series != seriesA {
 		t.Errorf("obtained wrong data for node 1")
 	}
 
-	if *GetData(monitor, Node("B"), metric) != seriesB {
+	if series, exists := GetData(monitor, Node("B"), metric); !exists || series != seriesB {
 		t.Errorf("obtained wrong data for node 2")
 	}
 
-	if GetData(monitor, Node("C"), metric) != nil {
+	if series, exists := GetData(monitor, Node("C"), metric); exists || series != nil {
 		t.Errorf("should not have obtained any data for node 3")
 	}
 

--- a/driver/monitoring/network/block_metrics.go
+++ b/driver/monitoring/network/block_metrics.go
@@ -95,9 +95,8 @@ func (s *BlockNetworkMetricSource[T]) GetSubjects() []monitoring.Network {
 	return []monitoring.Network{item}
 }
 
-func (s *BlockNetworkMetricSource[T]) GetData(monitoring.Network) *monitoring.BlockSeries[T] {
-	var res monitoring.BlockSeries[T] = s.series
-	return &res
+func (s *BlockNetworkMetricSource[T]) GetData(monitoring.Network) (monitoring.BlockSeries[T], bool) {
+	return s.series, true
 }
 
 func (s *BlockNetworkMetricSource[T]) Shutdown() error {

--- a/driver/monitoring/network/num_nodes.go
+++ b/driver/monitoring/network/num_nodes.go
@@ -73,9 +73,8 @@ func (s *numNodesSource) GetSubjects() []mon.Network {
 	return []mon.Network{{}}
 }
 
-func (s *numNodesSource) GetData(mon.Network) *mon.TimeSeries[int] {
-	var res mon.TimeSeries[int] = &s.data
-	return &res
+func (s *numNodesSource) GetData(mon.Network) (mon.TimeSeries[int], bool) {
+	return &s.data, true
 }
 
 func (s *numNodesSource) Shutdown() error {

--- a/driver/monitoring/network/num_nodes_test.go
+++ b/driver/monitoring/network/num_nodes_test.go
@@ -25,12 +25,12 @@ func TestNumNodeRetrievesNodeCount(t *testing.T) {
 	time.Sleep(200 * time.Millisecond)
 	source.Shutdown()
 
-	series := source.GetData(monitoring.Network{})
-	if series == nil {
-		t.Fatalf("failed to obtain data from source!")
+	series, exists := source.GetData(monitoring.Network{})
+	if series == nil || !exists {
+		t.Fatalf("failed to obtain data from source")
 	}
 
-	data := (*series).GetRange(monitoring.Time(0), monitoring.Time(math.MaxInt64))
+	data := series.GetRange(monitoring.Time(0), monitoring.Time(math.MaxInt64))
 	if len(data) == 0 {
 		t.Errorf("no data collected")
 	}

--- a/driver/monitoring/node/block_metrics.go
+++ b/driver/monitoring/node/block_metrics.go
@@ -98,16 +98,12 @@ func (s *BlockNodeMetricSource[T]) GetSubjects() []monitoring.Node {
 	return res
 }
 
-func (s *BlockNodeMetricSource[T]) GetData(node monitoring.Node) *monitoring.BlockSeries[T] {
+func (s *BlockNodeMetricSource[T]) GetData(node monitoring.Node) (monitoring.BlockSeries[T], bool) {
 	s.seriesLock.Lock()
 	defer s.seriesLock.Unlock()
 
-	if val, exists := s.series[node]; exists {
-		var res monitoring.BlockSeries[T] = val
-		return &res
-	}
-
-	return nil
+	res, exists := s.series[node]
+	return res, exists
 }
 
 func (s *BlockNodeMetricSource[T]) Shutdown() error {

--- a/driver/monitoring/node/block_progress.go
+++ b/driver/monitoring/node/block_progress.go
@@ -25,7 +25,7 @@ func init() {
 	}
 }
 
-// NewNumNodesSource creates a new data source periodically collecting data on
+// NewNodeBlockHeightSource creates a new data source periodically collecting data on
 // the block height at various nodes over time.
 func NewNodeBlockHeightSource(network driver.Network) mon.Source[mon.Node, mon.TimeSeries[int]] {
 	return newNodeBlockHeightSource(network, time.Second)

--- a/driver/monitoring/node/block_progress_test.go
+++ b/driver/monitoring/node/block_progress_test.go
@@ -82,12 +82,12 @@ func TestNodeBlockHeightSourceRetrievesBlockHeight(t *testing.T) {
 	}
 
 	for _, subject := range subjects {
-		data := source.GetData(subject)
-		if data == nil {
+		data, exists := source.GetData(subject)
+		if data == nil || !exists {
 			t.Errorf("no data found for node %s", subject)
 			continue
 		}
-		subrange := (*data).GetRange(mon.Time(0), mon.Time(math.MaxInt64))
+		subrange := data.GetRange(mon.Time(0), mon.Time(math.MaxInt64))
 		if len(subrange) == 0 {
 			t.Errorf("no data collected for node %s", subject)
 		}

--- a/driver/monitoring/node/node_source.go
+++ b/driver/monitoring/node/node_source.go
@@ -129,11 +129,11 @@ func (s *periodicNodeDataSource[T]) GetSubjects() []mon.Node {
 	return res
 }
 
-func (s *periodicNodeDataSource[T]) GetData(node mon.Node) *mon.TimeSeries[T] {
+func (s *periodicNodeDataSource[T]) GetData(node mon.Node) (mon.TimeSeries[T], bool) {
 	s.dataLock.Lock()
 	defer s.dataLock.Unlock()
-	var res mon.TimeSeries[T] = s.data[node]
-	return &res
+	res, exists := s.data[node]
+	return res, exists
 }
 
 func (s *periodicNodeDataSource[T]) Shutdown() error {

--- a/driver/monitoring/node/node_source_test.go
+++ b/driver/monitoring/node/node_source_test.go
@@ -91,12 +91,12 @@ func TestNodeSourceRetrievesSensorData(t *testing.T) {
 	}
 
 	for _, subject := range subjects {
-		data := source.GetData(subject)
-		if data == nil {
+		data, exists := source.GetData(subject)
+		if data == nil || !exists {
 			t.Errorf("no data found for node %s", subject)
 			continue
 		}
-		subrange := (*data).GetRange(mon.Time(0), mon.Time(math.MaxInt64))
+		subrange := data.GetRange(mon.Time(0), mon.Time(math.MaxInt64))
 		if len(subrange) == 0 {
 			t.Errorf("no data collected for node %s", subject)
 		}

--- a/driver/monitoring/source.go
+++ b/driver/monitoring/source.go
@@ -18,9 +18,10 @@ type Source[S any, T any] interface {
 	// available in this source. The list is expected to grow monotonies.
 	GetSubjects() []S
 
-	// GetData obtains the monitoring data retained for a selected subject
-	// or nil if there is no such data.
-	GetData(S) *T
+	// GetData obtains the monitoring data retained for a selected subject.
+	// The other argument returns false if the value for the subject does not exist, true otherwise.
+	// When true is returned, the first return parameter is not nil, otherwise it is unspecified.
+	GetData(S) (T, bool)
 }
 
 // source is a type-erased base type for sources. While its methods should

--- a/driver/monitoring/source_test.go
+++ b/driver/monitoring/source_test.go
@@ -34,12 +34,9 @@ func (s *TestSource) GetSubjects() []Node {
 	return res
 }
 
-func (s *TestSource) GetData(node Node) *BlockSeries[int] {
-	res := s.data[node]
-	if res == nil {
-		return nil
-	}
-	return &res
+func (s *TestSource) GetData(node Node) (BlockSeries[int], bool) {
+	res, exists := s.data[node]
+	return res, exists
 }
 func (s *TestSource) Start() error {
 	// Nothing to do.
@@ -89,13 +86,13 @@ func TestTestSource_RetrievesCorrectDataSeries(t *testing.T) {
 	source.setData(Node("A"), seriesA)
 	source.setData(Node("B"), seriesB)
 
-	if *source.GetData(Node("A")) != seriesA {
+	if series, exists := source.GetData(Node("A")); !exists || series != seriesA {
 		t.Errorf("test source returned wrong series")
 	}
-	if *source.GetData(Node("B")) != seriesB {
+	if series, exists := source.GetData(Node("B")); !exists || series != seriesB {
 		t.Errorf("test source returned wrong series")
 	}
-	if source.GetData(Node("C")) != nil {
+	if series, exists := source.GetData(Node("C")); exists || series != nil {
 		t.Errorf("test source returned wrong series")
 	}
 }

--- a/driver/norma/run.go
+++ b/driver/norma/run.go
@@ -133,18 +133,18 @@ func logState(monitor *monitoring.Monitor) {
 }
 
 func getNumNodes(monitor *monitoring.Monitor) string {
-	data := monitoring.GetData(monitor, monitoring.Network{}, netmon.NumberOfNodes)
-	return getLastValAsString[monitoring.Time, int](*data)
+	data, exists := monitoring.GetData(monitor, monitoring.Network{}, netmon.NumberOfNodes)
+	return getLastValAsString[monitoring.Time, int](exists, data)
 }
 
 func getNumTxs(monitor *monitoring.Monitor) string {
-	data := monitoring.GetData(monitor, monitoring.Network{}, netmon.BlockNumberOfTransactions)
-	return getLastValAsString[monitoring.BlockNumber, int](*data)
+	data, exists := monitoring.GetData(monitor, monitoring.Network{}, netmon.BlockNumberOfTransactions)
+	return getLastValAsString[monitoring.BlockNumber, int](exists, data)
 }
 
 func getGasUsed(monitor *monitoring.Monitor) string {
-	data := monitoring.GetData(monitor, monitoring.Network{}, netmon.BlockGasUsed)
-	return getLastValAsString[monitoring.BlockNumber, int](*data)
+	data, exists := monitoring.GetData(monitor, monitoring.Network{}, netmon.BlockGasUsed)
+	return getLastValAsString[monitoring.BlockNumber, int](exists, data)
 }
 
 func getBlockHeights(monitor *monitoring.Monitor) []string {
@@ -163,18 +163,14 @@ func getLastValAllSubjects[K constraints.Ordered, T any, X monitoring.Series[K, 
 
 	res := make([]string, 0, len(nodes))
 	for _, node := range nodes {
-		data := monitoring.GetData(monitor, node, metric)
-		if data == nil {
-			res = append(res, "N/A")
-			continue
-		}
-		res = append(res, getLastValAsString[K, T](*data))
+		data, exists := monitoring.GetData(monitor, node, metric)
+		res = append(res, getLastValAsString[K, T](exists, data))
 	}
 	return res
 }
 
-func getLastValAsString[K constraints.Ordered, T any](series monitoring.Series[K, T]) string {
-	if series == nil {
+func getLastValAsString[K constraints.Ordered, T any](exists bool, series monitoring.Series[K, T]) string {
+	if !exists || series == nil {
 		return "N/A"
 	}
 	point := series.GetLatest()


### PR DESCRIPTION
This PR changes the `GetData`() method of `Source` to use the `comma exists` idiom. 