### PR TITLE
Increase memory for GHCI on OSX

### DIFF
--- a/.github/workflows/go-osx.yml
+++ b/.github/workflows/go-osx.yml
@@ -6,6 +6,10 @@ on:
     paths:
       - '.github/workflows/go-osx.yml'
       - '**.go'
+  pull_request:
+    branches: [ "main" ]
+    paths:
+      - '.github/workflows/go-osx.yml'
 
 jobs:
 
@@ -25,7 +29,7 @@ jobs:
     - name: Set up Docker
       run: |
         brew install docker
-        colima start --memory 4
+        colima start --memory 8
 
     - name: Fetch Docker test-image
       run: docker image pull hello-world


### PR DESCRIPTION
This should fix failing OSX build.

It also enable running this test in pull request, but only when the GHCI config file itself is changed.