### PR TITLE
Add command line flag for DB implementation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,7 @@ COPY --from=build /client/carmen/go/lib/libcarmen.so .
 
 ENV VALIDATOR_NUMBER=1
 ENV VALIDATORS_COUNT=1
+ENV STATE_DB_IMPL="geth"
 ENV LD_LIBRARY_PATH=./
 
 EXPOSE 6060

--- a/driver/network.go
+++ b/driver/network.go
@@ -37,6 +37,8 @@ type Network interface {
 type NetworkConfig struct {
 	// NumberOfValidators is the (static) number of validators in the network.
 	NumberOfValidators int
+	// The name of the StateDB implementation to be used by network nodes.
+	StateDbImplementation string
 }
 
 // NetworkListener can be registered to networks to get callbacks whenever there

--- a/driver/node/opera.go
+++ b/driver/node/opera.go
@@ -64,6 +64,7 @@ func StartOperaDockerNode(client *docker.Client, config *OperaNodeConfig) (*Oper
 		Environment: map[string]string{
 			"VALIDATOR_NUMBER": validatorId,
 			"VALIDATORS_COUNT": fmt.Sprintf("%d", config.NetworkConfig.NumberOfValidators),
+			"STATE_DB_IMPL":    config.NetworkConfig.StateDbImplementation,
 		},
 	})
 	if err != nil {

--- a/scripts/run_opera.sh
+++ b/scripts/run_opera.sh
@@ -6,4 +6,4 @@ external_ip=${array[0]}
 echo "Opera is going to export its services on ${external_ip}"
 
 # Starting opera as part of a fake net with RPC service.
-./opera --fakenet ${VALIDATOR_NUMBER}/${VALIDATORS_COUNT} --statedb.impl=go-file --http --http.addr 0.0.0.0 --http.api admin,eth,ftm --nat=extip:${external_ip} --pprof --pprof.addr 0.0.0.0
+./opera --fakenet ${VALIDATOR_NUMBER}/${VALIDATORS_COUNT} --statedb.impl=${STATE_DB_IMPL} --http --http.addr 0.0.0.0 --http.api admin,eth,ftm --nat=extip:${external_ip} --pprof --pprof.addr 0.0.0.0


### PR DESCRIPTION
Adds a command line flag `--db-impl` to switch between `geth` and `carmen` as the StateDB implementation.

Unfortunately, I could not think of a way to unit-test this flag since I am not aware of a way to test which DB is running in a given node. I could add it to the log output of the node and read it from there if desired by reviewers.