### PR TITLE
Write CPU profiles to disk as they are collected

### DIFF
--- a/driver/monitoring/monitor.go
+++ b/driver/monitoring/monitor.go
@@ -18,13 +18,23 @@ import (
 // are free functions (see implementations below).
 type Monitor struct {
 	network         driver.Network
+	config          MonitorConfig
 	nodeLogProvider NodeLogProvider
 	sources         map[string]source
 }
 
+type MonitorConfig struct {
+	OutputDir string
+}
+
 // NewMonitor creates a new Monitor instance without any registered sources.
-func NewMonitor(network driver.Network) *Monitor {
-	return &Monitor{network, NewNodeLogDispatcher(network), map[string]source{}}
+func NewMonitor(network driver.Network, config MonitorConfig) *Monitor {
+	return &Monitor{
+		network:         network,
+		config:          config,
+		nodeLogProvider: NewNodeLogDispatcher(network),
+		sources:         map[string]source{},
+	}
 }
 
 // Shutdown disconnects all sources, stopping the collection of data. This
@@ -75,4 +85,15 @@ func GetData[S any, T any](monitor *Monitor, subject S, metric Metric[S, T]) (t 
 		return t, false
 	}
 	return source.(Source[S, T]).GetData(subject)
+}
+
+// GetNetwork returns a reference to the network monitored by this instance.
+func (m *Monitor) Network() driver.Network {
+	return m.network
+}
+
+// GetConfig returns general monitoring configuration options set for the given
+// monitor instance.
+func (m *Monitor) Config() MonitorConfig {
+	return m.config
 }

--- a/driver/monitoring/monitor_test.go
+++ b/driver/monitoring/monitor_test.go
@@ -15,7 +15,7 @@ func TestMonitor_CreateAndShutdown(t *testing.T) {
 	net.EXPECT().RegisterListener(gomock.Any()).AnyTimes()
 	net.EXPECT().GetActiveNodes().AnyTimes().Return([]driver.Node{})
 
-	monitor := NewMonitor(net)
+	monitor := NewMonitor(net, MonitorConfig{})
 	if err := monitor.Shutdown(); err != nil {
 		t.Errorf("shutdown of empty monitor failed: %v", err)
 	}
@@ -37,7 +37,7 @@ func TestMonitor_RegisterAndRetrievalOfDataWorks(t *testing.T) {
 
 	metric := source.GetMetric()
 
-	monitor := NewMonitor(net)
+	monitor := NewMonitor(net, MonitorConfig{})
 	if IsSupported(monitor, metric) {
 		t.Errorf("empty monitor should not support any metric")
 	}

--- a/driver/monitoring/node/cpu_profile_test.go
+++ b/driver/monitoring/node/cpu_profile_test.go
@@ -16,6 +16,7 @@ func TestCanCollectCpuProfileDateFromOperaNode(t *testing.T) {
 	}
 	defer docker.Close()
 	node, err := opera.StartOperaDockerNode(docker, &opera.OperaNodeConfig{
+		Label:         "test",
 		NetworkConfig: &driver.NetworkConfig{NumberOfValidators: 1},
 	})
 	if err != nil {

--- a/driver/network/local/local.go
+++ b/driver/network/local/local.go
@@ -74,9 +74,8 @@ func NewLocalNetwork(config *driver.NetworkConfig) (driver.Network, error) {
 	for i := 0; i < config.NumberOfValidators; i++ {
 		// TODO: create nodes in parallel
 		*nodeConfig.ValidatorId = i + 1
-		validator, err := net.createNode(&driver.NodeConfig{
-			Name: fmt.Sprintf("Validator-%d", i+1),
-		}, &nodeConfig)
+		nodeConfig.Label = fmt.Sprintf("Validator-%d", i+1)
+		validator, err := net.createNode(&nodeConfig)
 		if err != nil {
 			errs = append(errs, err)
 		} else {
@@ -98,7 +97,7 @@ func NewLocalNetwork(config *driver.NetworkConfig) (driver.Network, error) {
 
 // createNode is an internal version of CreateNode enabling the creation
 // of validator and non-validator nodes in the network.
-func (n *LocalNetwork) createNode(config *driver.NodeConfig, nodeConfig *node.OperaNodeConfig) (*node.OperaNode, error) {
+func (n *LocalNetwork) createNode(nodeConfig *node.OperaNodeConfig) (*node.OperaNode, error) {
 	node, err := node.StartOperaDockerNode(n.docker, nodeConfig)
 	if err != nil {
 		return nil, fmt.Errorf("failed to start opera docker; %v", err)
@@ -127,7 +126,8 @@ func (n *LocalNetwork) createNode(config *driver.NodeConfig, nodeConfig *node.Op
 
 // CreateNode creates non-validator nodes in the network.
 func (n *LocalNetwork) CreateNode(config *driver.NodeConfig) (driver.Node, error) {
-	return n.createNode(config, &node.OperaNodeConfig{
+	return n.createNode(&node.OperaNodeConfig{
+		Label:         config.Name,
 		NetworkConfig: &n.config,
 	})
 }

--- a/driver/node.go
+++ b/driver/node.go
@@ -12,6 +12,10 @@ import (
 // control of a node, allowing it to be started (through an Environment),
 // interact with the node, and shut it down.
 type Node interface {
+	// GetLabel returns a human-readable identifer for this node. Is is intended
+	// to label data and should be unique within a single scenario run.
+	GetLabel() string
+
 	// Returns true if the node is still running, false if stopped.
 	IsRunning() bool
 

--- a/driver/node/opera_test.go
+++ b/driver/node/opera_test.go
@@ -23,6 +23,7 @@ func TestOperaNode_StartAndStop(t *testing.T) {
 	}
 	defer docker.Close()
 	node, err := StartOperaDockerNode(docker, &OperaNodeConfig{
+		Label:         "test",
 		NetworkConfig: &driver.NetworkConfig{NumberOfValidators: 1},
 	})
 	if err != nil {
@@ -40,6 +41,7 @@ func TestOperaNode_RpcServiceIsReadyAfterStartup(t *testing.T) {
 	}
 	defer docker.Close()
 	node, err := StartOperaDockerNode(docker, &OperaNodeConfig{
+		Label:         "test",
 		NetworkConfig: &driver.NetworkConfig{NumberOfValidators: 1},
 	})
 	if err != nil {
@@ -63,8 +65,12 @@ func TestOperaNode_StreamLog(t *testing.T) {
 	})
 
 	node, err := StartOperaDockerNode(docker, &OperaNodeConfig{
+		Label:         "test",
 		NetworkConfig: &driver.NetworkConfig{NumberOfValidators: 1},
 	})
+	if err != nil {
+		t.Fatalf("failed to create an Opera node on Docker: %v", err)
+	}
 	t.Cleanup(func() {
 		_ = node.Cleanup()
 	})

--- a/driver/node_mock.go
+++ b/driver/node_mock.go
@@ -63,6 +63,20 @@ func (mr *MockNodeMockRecorder) GetHttpServiceUrl(arg0 interface{}) *gomock.Call
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHttpServiceUrl", reflect.TypeOf((*MockNode)(nil).GetHttpServiceUrl), arg0)
 }
 
+// GetLabel mocks base method.
+func (m *MockNode) GetLabel() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetLabel")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// GetLabel indicates an expected call of GetLabel.
+func (mr *MockNodeMockRecorder) GetLabel() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLabel", reflect.TypeOf((*MockNode)(nil).GetLabel))
+}
+
 // GetNodeID mocks base method.
 func (m *MockNode) GetNodeID() (NodeID, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
This PR adds the automatic recording of captured CPU profile data on disk.

To store profiling data, the following directory structure is used:
```
<monitoring_data_directory/cpu_profiles/<node_label>/<profile_number>.prof
```

To that end, a human-readable `label` was added to the `Node` interface to be used for the unique identification of nodes within a scenario setup.

Example file structure:
```
.
└── cpu_profiles
    ├── A-0
    │   ├── 000000.prof
    │   └── 000001.prof
    ├── A-1
    │   ├── 000000.prof
    │   └── 000001.prof
    ├── A-2
    │   ├── 000000.prof
    │   └── 000001.prof
    └── Validator-1
        ├── 000000.prof
        └── 000001.prof
```