### PR TITLE
create applications before they are scheduled

### DIFF
--- a/driver/executor/clock.go
+++ b/driver/executor/clock.go
@@ -12,6 +12,9 @@ type Clock interface {
 	// of time as implemented by a given clock.
 	Now() Time
 
+	// Restart starts ticking of this clock, if the clock was already ticking, it is reset.
+	Restart()
+
 	// Suspends execution until the given time (+/- a few milliseconds).
 	SleepUntil(Time) error
 
@@ -59,6 +62,10 @@ func (c *SimClock) Now() Time {
 	return c.now
 }
 
+func (c *SimClock) Restart() {
+	c.now = 0
+}
+
 func (c *SimClock) SleepUntil(time Time) error {
 	if c.now < time {
 		c.now = time
@@ -87,6 +94,10 @@ func NewWallTimeClock() Clock {
 
 func (c *WallTimeClock) Now() Time {
 	return Time(time.Since(c.startTime))
+}
+
+func (c *WallTimeClock) Restart() {
+	c.startTime = time.Now()
 }
 
 func (c *WallTimeClock) SleepUntil(deadline Time) error {

--- a/driver/executor/clock_test.go
+++ b/driver/executor/clock_test.go
@@ -2,6 +2,7 @@ package executor
 
 import (
 	"testing"
+	"time"
 )
 
 type namedClock struct {
@@ -76,6 +77,24 @@ func TestClock_NotifyAtSkipsTimeAccurately(t *testing.T) {
 			if offset > Milliseconds(1) {
 				t.Errorf("delay between weak-up time and clock time is to high: %v", offset)
 			}
+		})
+	}
+}
+
+func TestClock_Start(t *testing.T) {
+	for _, test := range getClocks() {
+		t.Run(test.name, func(t *testing.T) {
+			clock := test.clock
+			t1 := clock.Now()
+			// wait and reset - the time diff must be below or zero
+			time.Sleep(100 * time.Millisecond)
+			clock.Restart()
+			t2 := clock.Now()
+			diff := time.Duration(t2 - t1)
+			if diff > 0 {
+				t.Errorf("time has not reset")
+			}
+
 		})
 	}
 }

--- a/load/generator/counter_generator.go
+++ b/load/generator/counter_generator.go
@@ -97,8 +97,11 @@ func (f *CounterGeneratorFactory) Create() (TransactionGenerator, error) {
 	}
 	// adjust txOpts for the runtime to avoid slow loading of gasPrice/nonce from RPC for each tx
 	txOpts.Nonce = big.NewInt(int64(nonce))
-	txOpts.GasLimit = 50000    // IncrementCounter method call takes 43426 of gas
-	txOpts.GasPrice = gasPrice // use static gasPrice
+	txOpts.GasLimit = 50000 // IncrementCounter method call takes 43426 of gas
+	// use static gasPrice - multiply recommended gas price by two to have some levy
+	// for the cases the min gas price is increased by the network,
+	// and we do not have to query the gas price before every transaction.
+	txOpts.GasPrice = gasPrice.Mul(gasPrice, big.NewInt(int64(2)))
 
 	gen := &CounterGenerator{
 		rpcClient:       rpcClient,


### PR DESCRIPTION
This PR creates applications before they are added and scheduled into the queue. It is because creation of applications may be time consuming (easily taking minutes), which brakes schedule of actual experiment. 

In addition the timer is reset just before the start of experiment so the creation time is excluded from the experiment.
 (I was thinking to create a new clock via a factory method instead of adding the Reset() method, not sure what is better)