### PR TITLE
Check block hash at the end of rpc unit test

### DIFF
--- a/driver/node/opera.go
+++ b/driver/node/opera.go
@@ -169,14 +169,14 @@ func (n *OperaNode) AddPeer(id driver.NodeID) error {
 	return rpcClient.Call(nil, "admin_addPeer", id)
 }
 
-type BlockDetail struct {
+type BlockHeader struct {
 	Number    *hexutil.Big
 	Hash      string
 	Epoch     hexutil.Uint64
 	StateRoot string
 }
 
-func (n *OperaNode) GetBlock(number string) (*BlockDetail, error) {
+func (n *OperaNode) GetBlock(number string) (*BlockHeader, error) {
 	url := n.GetServiceUrl(&OperaRpcService)
 	if url == nil {
 		return nil, fmt.Errorf("node does not export an RPC server")
@@ -185,7 +185,7 @@ func (n *OperaNode) GetBlock(number string) (*BlockDetail, error) {
 	if err != nil {
 		return nil, err
 	}
-	var blockDetail BlockDetail
+	var blockDetail BlockHeader
 	err = rpcClient.Call(&blockDetail, "ftm_getBlockByNumber", number, false)
 	if err != nil {
 		return nil, err

--- a/load/controller/rpc_test.go
+++ b/load/controller/rpc_test.go
@@ -57,7 +57,7 @@ func TestTrafficGenerating(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// add a RPC node, which have been added when chain already contained txs
+	// add an RPC node, which has been added when chain already contained txs
 	_, err = net.CreateNode(&driver.NodeConfig{
 		Name: "RPC-Later-Added",
 	})
@@ -102,7 +102,7 @@ func TestTrafficGenerating(t *testing.T) {
 
 // checkLatestBlockMatches compares hashes of the latest block and the state root across given nodes
 func checkLatestBlockMatches(t *testing.T, nodes []driver.Node) {
-	var latestBlock *node.BlockDetail
+	var latestBlock *node.BlockHeader
 	var err error
 	for _, n := range nodes {
 		operaNode := n.(*node.OperaNode)


### PR DESCRIPTION
As discussed, we should make sure the node, which joins to the network later, is synced correctly.
This adds obtaining of the block hash at the end of the rpc unit test, together with starting the later-starting rpc node.