### PR TITLE
implements aggregation source to compute SMA of series

### DIFF
--- a/driver/monitoring/node/sma_source.go
+++ b/driver/monitoring/node/sma_source.go
@@ -1,0 +1,110 @@
+package nodemon
+
+import (
+	"fmt"
+	"github.com/Fantom-foundation/Norma/driver/monitoring"
+	"github.com/Fantom-foundation/Norma/driver/monitoring/export"
+	"golang.org/x/exp/constraints"
+	"sync"
+)
+
+func init() {
+	smaPeriods := []int{10, 100, 1000}
+	for _, period := range smaPeriods {
+
+		// TransactionThroughputSMA is a metric that aggregates output from another series and computes
+		// Simple Moving Average.
+		TransactionThroughputSMA := monitoring.Metric[monitoring.Node, monitoring.BlockSeries[float32]]{
+			Name:        fmt.Sprintf("TransactionsThroughputSMA_%d", period),
+			Description: "Transaction throughput standard moving average",
+		}
+
+		smaFactory := func(input monitoring.BlockSeries[float32]) monitoring.BlockSeries[float32] {
+			return monitoring.NewSMASeries[monitoring.BlockNumber, float32](input, period)
+		}
+		metricsFactory := func(monitor *monitoring.Monitor) monitoring.Source[monitoring.Node, monitoring.BlockSeries[float32]] {
+			return newNodeBlockSeriesTransformation(monitor, TransactionThroughputSMA, TransactionsThroughput, smaFactory)
+		}
+
+		if err := monitoring.RegisterSource(TransactionThroughputSMA, metricsFactory); err != nil {
+			panic(fmt.Sprintf("failed to register metric source: %v", err))
+		}
+	}
+}
+
+// NodeBlockSeriesTransformation is a source that captures an input source, and computes certain transformation on top of it.
+// The input source for this type must have the node as a subject and the Series as a value.
+// This type produces the same Nodes as the subjects and the series with the required transformation.
+type NodeBlockSeriesTransformation[K constraints.Ordered, T any, X monitoring.Series[K, T]] struct {
+	metric        monitoring.Metric[monitoring.Node, X]
+	source        monitoring.Metric[monitoring.Node, X] // source metrics to transform
+	monitor       *monitoring.Monitor
+	series        map[monitoring.Node]X
+	seriesFactory func(X) X // transform input series to the output series
+	seriesLock    *sync.Mutex
+}
+
+// NewNodeSeriesTransformation creates a new source that can transform input source to the output source.
+// This transformation is limited to the source where the Node is the subject and values are series.
+// The output source is transformed to contain the same subjects, which addresses new, transformed, series
+func NewNodeSeriesTransformation[K constraints.Ordered, T any, X monitoring.Series[K, T]](
+	monitor *monitoring.Monitor,
+	metric monitoring.Metric[monitoring.Node, X],
+	source monitoring.Metric[monitoring.Node, X],
+	seriesFactory func(X) X) *NodeBlockSeriesTransformation[K, T, X] {
+
+	m := &NodeBlockSeriesTransformation[K, T, X]{
+		metric:        metric,
+		source:        source,
+		seriesFactory: seriesFactory,
+		monitor:       monitor,
+		series:        make(map[monitoring.Node]X, 50),
+		seriesLock:    &sync.Mutex{},
+	}
+
+	return m
+}
+
+// newNodeBlockSeriesTransformation creates the same instance as public NewNodeSeriesTransformation but typed to the BlockSeries as a Series.
+func newNodeBlockSeriesTransformation[T any](
+	monitor *monitoring.Monitor,
+	metric monitoring.Metric[monitoring.Node, monitoring.BlockSeries[T]],
+	source monitoring.Metric[monitoring.Node, monitoring.BlockSeries[T]],
+	seriesFactory func(monitoring.BlockSeries[T]) monitoring.BlockSeries[T]) monitoring.Source[monitoring.Node, monitoring.BlockSeries[T]] {
+
+	res := NewNodeSeriesTransformation[monitoring.BlockNumber, T, monitoring.BlockSeries[T]](monitor, metric, source, seriesFactory)
+	monitor.Writer().Add(func() error {
+		return export.AddNodeBlockSeriesSource[T](monitor.Writer(), res, export.DirectConverter[T]{})
+	})
+
+	return res
+}
+
+func (s *NodeBlockSeriesTransformation[K, T, X]) GetMetric() monitoring.Metric[monitoring.Node, X] {
+	return s.metric
+}
+
+func (s *NodeBlockSeriesTransformation[K, T, X]) GetSubjects() []monitoring.Node {
+	return monitoring.GetSubjects(s.monitor, s.source)
+}
+
+func (s *NodeBlockSeriesTransformation[K, T, X]) GetData(node monitoring.Node) (X, bool) {
+	s.seriesLock.Lock()
+	defer s.seriesLock.Unlock()
+
+	res, exists := s.series[node]
+	if !exists {
+		source, existsSource := monitoring.GetData(s.monitor, node, s.source)
+		if existsSource {
+			newSeries := s.seriesFactory(source)
+			s.series[node] = newSeries
+			return newSeries, true
+		}
+	}
+
+	return res, exists
+}
+
+func (s *NodeBlockSeriesTransformation[K, T, X]) Shutdown() error {
+	return nil
+}

--- a/driver/monitoring/node/sma_source_test.go
+++ b/driver/monitoring/node/sma_source_test.go
@@ -1,0 +1,140 @@
+package nodemon
+
+import (
+	"fmt"
+	"github.com/Fantom-foundation/Norma/driver"
+	"github.com/Fantom-foundation/Norma/driver/monitoring"
+	"github.com/golang/mock/gomock"
+	"os"
+	"testing"
+	"time"
+)
+
+func TestSMASource(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	net := driver.NewMockNetwork(ctrl)
+	net.EXPECT().RegisterListener(gomock.Any()).AnyTimes()
+	net.EXPECT().GetActiveNodes().Return([]driver.Node{}).AnyTimes()
+
+	writer := monitoring.NewMockWriterChain(ctrl)
+	writer.EXPECT().Add(gomock.Any()).AnyTimes()
+
+	monitor := monitoring.NewMonitor(net, monitoring.MonitorConfig{}, writer)
+
+	source := NewTransactionsThroughputSource(monitoring.NewMonitor(net, monitoring.MonitorConfig{}, writer))
+	sf := sourceFactory[monitoring.Node, monitoring.BlockSeries[float32]]{TransactionsThroughput, source}
+	if err := monitoring.InstallSource[monitoring.Node, monitoring.BlockSeries[float32]](monitor, &sf); err != nil {
+		t.Fatalf("failed to install source: %v", err)
+	}
+
+	period := 2
+	smaFactory := func(input monitoring.BlockSeries[float32]) monitoring.BlockSeries[float32] {
+		return monitoring.NewSMASeries[monitoring.BlockNumber, float32](input, period)
+	}
+	TransactionThroughputSMA := monitoring.Metric[monitoring.Node, monitoring.BlockSeries[float32]]{
+		Name:        fmt.Sprintf("TransactionThroughputSMA_%d", period),
+		Description: "Transaction throughput standard moving average",
+	}
+
+	smaSource := newNodeBlockSeriesTransformation(monitor, TransactionThroughputSMA, TransactionsThroughput, smaFactory)
+
+	// fill in original source with data
+	for node, blocks := range monitoring.NodeBlockTestData {
+		for _, block := range blocks {
+			source.OnBlock(node, block)
+		}
+	}
+
+	expected := map[monitoring.Node][]float32{
+		monitoring.Node1TestId: {43.763676, 52.494083},
+		monitoring.Node2TestId: {40.733196},
+		monitoring.Node3TestId: {},
+	}
+
+	// test SMA computed for each node
+	for node := range monitoring.NodeBlockTestData {
+		series, exists := smaSource.GetData(node)
+		if !exists {
+			t.Errorf("series does not exist for subject: %v", node)
+		}
+
+		points := series.GetRange(monitoring.BlockNumber(0), monitoring.BlockNumber(1000))
+		for i, block := range points {
+			if got, want := block.Value, expected[node][i]; got != want {
+				t.Errorf("data series contain unexpected value for: %v: %v != %v", node, got, want)
+			}
+		}
+
+		if got, want := len(points), len(expected[node]); got != want {
+			t.Errorf("number of points does not mathc: %d != %d", got, want)
+		}
+	}
+
+	// test subjects present
+	for _, node := range smaSource.GetSubjects() {
+		if _, exists := monitoring.NodeBlockTestData[node]; !exists {
+			t.Errorf("subject %v is not present", node)
+		}
+	}
+
+	if got, want := len(smaSource.GetSubjects()), len(monitoring.NodeBlockTestData); got != want {
+		t.Errorf("number of subjects does not mathc: %d != %d", got, want)
+	}
+}
+
+func TestSMACsvExport(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	net := driver.NewMockNetwork(ctrl)
+	net.EXPECT().RegisterListener(gomock.Any()).AnyTimes()
+	net.EXPECT().GetActiveNodes().AnyTimes().Return([]driver.Node{})
+
+	csvFile, _ := os.CreateTemp(t.TempDir(), "file.csv")
+	writer := monitoring.NewWriterChain(csvFile)
+
+	monitor := monitoring.NewMonitor(net, monitoring.MonitorConfig{}, writer)
+	source := NewTransactionsThroughputSource(monitoring.NewMonitor(net, monitoring.MonitorConfig{}, writer))
+	sf := sourceFactory[monitoring.Node, monitoring.BlockSeries[float32]]{TransactionsThroughput, source}
+	if err := monitoring.InstallSource[monitoring.Node, monitoring.BlockSeries[float32]](monitor, &sf); err != nil {
+		t.Fatalf("failed to install source: %v", err)
+	}
+
+	period := 2
+	smaFactory := func(input monitoring.BlockSeries[float32]) monitoring.BlockSeries[float32] {
+		return monitoring.NewSMASeries[monitoring.BlockNumber, float32](input, period)
+	}
+	TransactionThroughputSMA := monitoring.Metric[monitoring.Node, monitoring.BlockSeries[float32]]{
+		Name:        fmt.Sprintf("TransactionThroughputSMA_%d", period),
+		Description: "Transaction throughput standard moving average",
+	}
+
+	newNodeBlockSeriesTransformation(monitor, TransactionThroughputSMA, TransactionsThroughput, smaFactory)
+
+	seconds := time.Now().Unix()
+	// time diff only 50ns
+	source.OnBlock("A", monitoring.Block{Height: 10, Time: time.Unix(seconds, 0), Txs: 10})
+	source.OnBlock("A", monitoring.Block{Height: 11, Time: time.Unix(seconds+1, 0), Txs: 10})
+	_ = writer.Close()
+
+	content, _ := os.ReadFile(csvFile.Name())
+	if got, want := string(content),
+		"TransactionsThroughput, network, A, , , 11, , 10\n"+
+			"TransactionThroughputSMA_2, network, A, , , 11, , 10\n"; got != want {
+
+		t.Errorf("unexpected export: %v != %v", got, want)
+	}
+}
+
+type sourceFactory[S any, T any] struct {
+	metric monitoring.Metric[S, T]
+	source monitoring.Source[S, T]
+}
+
+func (f *sourceFactory[S, T]) GetMetric() monitoring.Metric[S, T] {
+	return f.metric
+}
+
+func (f *sourceFactory[S, T]) CreateSource(*monitoring.Monitor) monitoring.Source[S, T] {
+	return f.source
+}

--- a/driver/monitoring/sma_series.go
+++ b/driver/monitoring/sma_series.go
@@ -1,0 +1,82 @@
+package monitoring
+
+import (
+	"golang.org/x/exp/constraints"
+	"log"
+)
+
+// Number is a constraint type for float and integer types.
+type Number interface {
+	constraints.Float | constraints.Integer
+}
+
+// SmaSeries is computes a Simple Moving Average from the input series and stores it to this series.
+// Everytime methods to get data from this series are called, calculation of the average is triggered.
+// It is always checked if the input series has grown since and potential missing averages are computed and added to this series.
+// The moving average is computed fow a moving window sized to the configured period.
+// If the input series is shorter, the window used is smaller and the average computed for this smaller window.
+type SmaSeries[K constraints.Ordered, T Number] struct {
+	input            Series[K, T]
+	output           *SyncedSeries[K, T]
+	startKey, endKey K // keep positions of first end last element of the window
+	period           int
+}
+
+func NewSMASeries[K constraints.Ordered, T Number](input Series[K, T], period int) *SmaSeries[K, T] {
+	return &SmaSeries[K, T]{
+		input:  input,
+		output: &SyncedSeries[K, T]{},
+		period: period,
+	}
+}
+
+func (s *SmaSeries[K, T]) calculate() {
+	latest := s.input.GetLatest()
+	if latest != nil && (latest.Position > s.endKey || s.endKey == s.startKey) {
+		var sum T
+		points := append(s.input.GetRange(s.startKey, latest.Position), *latest)
+
+		// This loop moves the window from the start key to the end of the input series.
+		// SMA is computed and added to the output series for the moving window.
+		// The key marking the start of the rolling window is stored globally to restart
+		// rolling from the beginning of the window when this method is repeatedly called.
+		for i, point := range points {
+			sum += point.Value
+
+			// the window started to move
+			// - move key of the start of the window
+			// - reduce the sum of the value before the start of the window
+			if i >= s.period {
+				s.startKey = points[i-s.period].Position
+				sum -= points[i-s.period].Value // remove the value before this window start
+			}
+
+			// compute and store averages for not already included keys
+			// or when the series is empty (i.e. last and end keys are equal)
+			if point.Position > s.endKey || s.endKey == s.startKey {
+				count := T(s.period)
+				if i < s.period {
+					count = T(i + 1)
+				}
+				avr := sum / count
+				s.endKey = point.Position
+				if err := s.output.Append(s.endKey, avr); err != nil {
+					log.Printf("err: %v", err)
+				}
+			}
+		}
+
+	}
+}
+
+// GetRange extracts a snapshot of a value range of the maintained output.
+func (s *SmaSeries[K, T]) GetRange(from, to K) []DataPoint[K, T] {
+	s.calculate()
+	return s.output.GetRange(from, to)
+}
+
+// GetLatest returns the latest collected output point in this series.
+func (s *SmaSeries[K, T]) GetLatest() *DataPoint[K, T] {
+	s.calculate()
+	return s.output.GetLatest()
+}

--- a/driver/monitoring/sma_series_test.go
+++ b/driver/monitoring/sma_series_test.go
@@ -1,0 +1,107 @@
+package monitoring
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestSmaSeriesIsSeries(t *testing.T) {
+	inst := SmaSeries[int, int]{}
+	var _ Series[int, int] = &inst
+}
+
+func TestSmaSeriesComputeSMA(t *testing.T) {
+	input := []float64{1, 3, 5, 10, 30, 50, 100, 300, 500}
+	extraInput := []float64{1000, 3000, 5000}
+
+	windowSizes := map[int][]float64{
+		2: {1, 2, 4, 7.5, 20, 40, 75, 200, 400, 750, 2000, 4000},
+		4: {1, 2, 3, 4.75, 12, 23.75, 47.5, 120, 237.5, 475, 1200, 2375},
+		8: {1, 2, 3, 4.75, 9.8, 16.5, 28.42857143, 62.375, 124.75, 249.375, 623.75, 1247.5},
+	}
+
+	for window, expected := range windowSizes {
+		t.Run(fmt.Sprintf("window: %d", window), func(t *testing.T) {
+
+			series := &SyncedSeries[float64, float64]{}
+			for i, val := range input {
+				_ = series.Append(float64(i), val)
+			}
+			smaSeries := NewSMASeries[float64, float64](series, window)
+
+			var start float64
+			var size int
+			latest := smaSeries.GetLatest()
+			points := smaSeries.GetRange(start, latest.Position)
+			for i, point := range points {
+				if got, want := fmt.Sprintf("%.2f", point.Value), fmt.Sprintf("%.2f", expected[i]); got != want {
+					t.Errorf("values do not match: %v != %v", got, want)
+				}
+				size++
+			}
+
+			// check last value
+			if got, want := (*smaSeries.GetLatest()).Value, expected[size]; got != want {
+				t.Errorf("values do not match: %v != %v", got, want)
+			}
+
+			// add more values, SMA will be computed for an extra values
+			for i, val := range extraInput {
+				if err := series.Append(float64(i+size+1), val); err != nil {
+					t.Errorf("cannot insert value: %s", err)
+				}
+			}
+			latest2 := smaSeries.GetLatest()
+			extraPoints := append(smaSeries.GetRange(latest.Position, latest2.Position), *latest2)
+			shift := size
+			for i, point := range extraPoints {
+				if got, want := fmt.Sprintf("%.2f", point.Value), fmt.Sprintf("%.2f", expected[i+shift]); got != want {
+					t.Errorf("values do not match: %v != %v", got, want)
+				}
+				size++
+			}
+
+			if size != len(expected) {
+				t.Errorf("sizes do not match: %d != %d", size, len(expected))
+			}
+		})
+	}
+}
+
+func TestSmaSeriesComputeSMASingleValue(t *testing.T) {
+	series := &SyncedSeries[float64, float64]{}
+	smaSeries := NewSMASeries[float64, float64](series, 4)
+
+	// add value, SMA will be computed for an extra value
+	if err := series.Append(float64(0), 1000); err != nil {
+		t.Errorf("cannot add value: %s", err)
+	}
+	if got, want := (*smaSeries.GetLatest()).Value, float64(1000); got != want {
+		t.Errorf("values do not match: %v != %v", got, want)
+	}
+}
+
+func TestSmaSeriesComputeSMANegativeValues(t *testing.T) {
+	series := &SyncedSeries[int, float64]{}
+	smaSeries := NewSMASeries[int, float64](series, 4)
+
+	values := []int{-5, -6, -7, -8, 8, 7, 6, 5}
+	for i, val := range values {
+		if err := series.Append(i, float64(val)); err != nil {
+			t.Errorf("cannot add value: %s", err)
+		}
+	}
+
+	if got, want := (*smaSeries.GetLatest()).Value, 6.5; got != want {
+		t.Errorf("values do not match: %v != %v", got, want)
+	}
+}
+
+func TestSmaSeriesEmpty(t *testing.T) {
+	series := &SyncedSeries[float64, float64]{}
+	smaSeries := NewSMASeries[float64, float64](series, 4)
+
+	if point := smaSeries.GetLatest(); point != nil {
+		t.Errorf("point should not exist")
+	}
+}


### PR DESCRIPTION
This PR introduces a new metric, which computes Simple Moving Average on top of any other metrics. 
It creates three instances of the metric for 10, 100 and 1000 bars of the underlying series. 
This Metric can be used for plotting smoothened lines directly out of the raw data. There is already a trend line in google sheet, but its SMA can be applied to 10 bars only and it is a bit inconvenient to add the trend lines where there is many lines and the chart is crowded.  