### PR TITLE
Kjezek/prevent na n or inf for txs throuhghput

### DIFF
--- a/driver/monitoring/node/transactions_throughput.go
+++ b/driver/monitoring/node/transactions_throughput.go
@@ -69,13 +69,11 @@ func (s *TransactionsThroughputSource) OnBlock(node monitoring.Node, block monit
 	}
 
 	timeDiff := block.Time.Sub(prevTime).Nanoseconds()
-	if timeDiff == 0 {
-		// prevent NaN or Inf: when the time difference is bellow measured value, sets to one nanosec.
-		// (Opera log uses millis precision
-		timeDiff = time.Duration(1).Nanoseconds()
-	}
-	txs := float64(block.Txs) * 1e9 / float64(timeDiff)
-	if err := s.series[node].Append(monitoring.BlockNumber(block.Height), float32(txs)); err != nil {
-		log.Printf("error to add to the series: %s", err)
+	// prevent NaN or Inf: when the time difference is bellow measured value, skip the block.
+	if timeDiff != 0 {
+		txs := float64(block.Txs) * 1e9 / float64(timeDiff)
+		if err := s.series[node].Append(monitoring.BlockNumber(block.Height), float32(txs)); err != nil {
+			log.Printf("error to add to the series: %s", err)
+		}
 	}
 }

--- a/driver/monitoring/node/transactions_throughput_test.go
+++ b/driver/monitoring/node/transactions_throughput_test.go
@@ -135,8 +135,8 @@ func TestTransactionsBellowMeasurableDiff(t *testing.T) {
 	source.OnBlock("A", monitoring.Block{Height: 11, Time: time.Unix(seconds, 0), Txs: 10})
 
 	series, _ := source.GetData("A")
-	if got, want := series.GetLatest().Value, float32(10/1e-9); got != want {
-		t.Errorf("througput does not match: %v != %v", got, want)
+	if got := series.GetLatest(); got != nil {
+		t.Errorf("there should be no value")
 	}
 }
 
@@ -158,7 +158,7 @@ func TestTransactionsZeroTransactionsBellowMeasurableDiff(t *testing.T) {
 	source.OnBlock("A", monitoring.Block{Height: 11, Time: time.Unix(seconds, 0), Txs: 0})
 
 	series, _ := source.GetData("A")
-	if got, want := series.GetLatest().Value, float32(0); got != want {
-		t.Errorf("througput does not match: %v != %v", got, want)
+	if got := series.GetLatest(); got != nil {
+		t.Errorf("there should be no value")
 	}
 }


### PR DESCRIPTION
This PR modifies the TransactionThroughput metrics, it lets the metric skip blocks where the speed cannot be computed because the time diff is bellow measurement scale, i.e the diff becomes zero. In this cases the tx/s was +Inf. Excel filters out these values anyway and they caused problems for computation of SMA 