### PR TITLE
Increase budget of tx generators, funding into a helper function

### DIFF
--- a/load/app/account.go
+++ b/load/app/account.go
@@ -50,14 +50,15 @@ func GenerateAccount(chainID int64) (*Account, error) {
 }
 
 // GenerateAndFundAccount creates a new Account with a random private key and transfer finances to cover txs fees
-func GenerateAndFundAccount(sourceAccount *Account, rpcClient RpcClient, gasPrice *big.Int) (*Account, error) {
+func GenerateAndFundAccount(sourceAccount *Account, rpcClient RpcClient, regularGasPrice *big.Int) (*Account, error) {
+	priorityGasPrice := getPriorityGasPrice(regularGasPrice)
 	account, err := GenerateAccount(sourceAccount.chainID.Int64())
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate account; %v", err)
 	}
 	// transfers 1000 FTM to the new account - finances to cover transaction fees
 	workerBudget := big.NewInt(0).Mul(big.NewInt(1000), big.NewInt(1_000000000000000000))
-	if err := transferValue(rpcClient, sourceAccount, account.address, workerBudget, gasPrice); err != nil {
+	if err := transferValue(rpcClient, sourceAccount, account.address, workerBudget, priorityGasPrice); err != nil {
 		return nil, fmt.Errorf("failed to fund account: %v", err)
 	}
 	return account, nil

--- a/load/app/counter_app.go
+++ b/load/app/counter_app.go
@@ -69,13 +69,13 @@ type CounterApplication struct {
 func (f *CounterApplication) CreateGenerator(rpcClient RpcClient) (TransactionGenerator, error) {
 
 	// get price of gas from the network
-	priorityGasPrice, regularGasPrice, err := getGasPrice(rpcClient)
+	regularGasPrice, err := getGasPrice(rpcClient)
 	if err != nil {
 		return nil, err
 	}
 
 	// generate a new account for each worker - avoid account nonces related bottlenecks
-	workerAccount, err := GenerateAndFundAccount(f.primaryAccount, rpcClient, priorityGasPrice)
+	workerAccount, err := GenerateAndFundAccount(f.primaryAccount, rpcClient, regularGasPrice)
 	if err != nil {
 		return nil, err
 	}

--- a/load/app/erc20_app.go
+++ b/load/app/erc20_app.go
@@ -85,13 +85,13 @@ type ERC20Application struct {
 // CreateGenerator creates a new transaction generator for the app.
 func (f *ERC20Application) CreateGenerator(rpcClient RpcClient) (TransactionGenerator, error) {
 	// get price of gas from the network
-	priorityGasPrice, regularGasPrice, err := getGasPrice(rpcClient)
+	regularGasPrice, err := getGasPrice(rpcClient)
 	if err != nil {
 		return nil, err
 	}
 
 	// generate a new account for each worker - avoid account nonces related bottlenecks
-	workerAccount, err := GenerateAndFundAccount(f.primaryAccount, rpcClient, priorityGasPrice)
+	workerAccount, err := GenerateAndFundAccount(f.primaryAccount, rpcClient, regularGasPrice)
 	if err != nil {
 		return nil, err
 	}
@@ -105,7 +105,7 @@ func (f *ERC20Application) CreateGenerator(rpcClient RpcClient) (TransactionGene
 	if err != nil {
 		return nil, fmt.Errorf("failed to create txOpts; %v", err)
 	}
-	txOpts.GasPrice = priorityGasPrice
+	txOpts.GasPrice = getPriorityGasPrice(regularGasPrice)
 	txOpts.Nonce = big.NewInt(int64(f.primaryAccount.getNextNonce()))
 	_, err = erc20Contract.Mint(txOpts, workerAccount.address, big.NewInt(1_000000000000000000))
 	if err != nil {

--- a/load/app/helpers.go
+++ b/load/app/helpers.go
@@ -48,14 +48,19 @@ func waitUntilAccountNonceIs(account common.Address, awaitedNonce uint64, rpcCli
 	return fmt.Errorf("nonce not achieved before timeout (awaited %d, current %d)", awaitedNonce, nonce)
 }
 
-// getGasPrice obtains optimal gasPrice for priority (initializing) and for regular transactions
-func getGasPrice(rpcClient RpcClient) (*big.Int, *big.Int, error) {
+// getGasPrice obtains optimal gasPrice for regular transactions
+func getGasPrice(rpcClient RpcClient) (*big.Int, error) {
 	gasPrice, err := rpcClient.SuggestGasPrice(context.Background())
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to suggest gas price; %v", err)
+		return nil, fmt.Errorf("failed to suggest gas price; %v", err)
 	}
-	var priorityPrice, regularPrice big.Int
-	priorityPrice.Mul(gasPrice, big.NewInt(4)) // greater gas price for init
-	regularPrice.Mul(gasPrice, big.NewInt(2))  // lower gas price for regular txs
-	return &priorityPrice, &regularPrice, nil
+	var regularPrice big.Int
+	regularPrice.Mul(gasPrice, big.NewInt(2)) // lower gas price for regular txs (but more than suggested by Opera)
+	return &regularPrice, nil
+}
+
+func getPriorityGasPrice(regularGasPrice *big.Int) *big.Int {
+	var priorityPrice big.Int
+	priorityPrice.Mul(regularGasPrice, big.NewInt(2)) // greater gas price for init
+	return &priorityPrice
 }


### PR DESCRIPTION
This increase the generator workers budget from 10 FTM to 1000 FTM and moves the code responsible for budget and gasPrice calculation into shared helper functions, to keep this in sync across different apps.

(the budget increase have been already done by Kamil for Counter app, but this was lost in generators refactoring)

This resolves `failed to send tx; insufficient funds for gas * price + value` error.