### PR TITLE
updates service registration to run pprof and metrics in parallel, ma…

### DIFF
--- a/driver/monitoring/node/cpu_profile.go
+++ b/driver/monitoring/node/cpu_profile.go
@@ -17,7 +17,7 @@ import (
 type PprofData []byte
 
 func GetPprofData(node driver.Node, duration time.Duration) (PprofData, error) {
-	url := node.GetServiceUrl(&opera.OperaPprofService)
+	url := node.GetServiceUrl(&opera.OperaDebugService)
 	if url == nil {
 		return nil, fmt.Errorf("node does not offer the pprof service")
 	}

--- a/driver/network/service.go
+++ b/driver/network/service.go
@@ -15,6 +15,28 @@ type ServiceDescription struct {
 	Protocol string
 }
 
+type ServiceGroup map[Port]*ServiceDescription
+
+// RegisterService installs a supported service in the registry.
+func (s *ServiceGroup) RegisterService(service *ServiceDescription) error {
+	if _, exists := (*s)[service.Port]; exists {
+		return fmt.Errorf("port %d already assigned - it is not supported to bind the same port many times", service.Port)
+	}
+
+	(*s)[service.Port] = service
+	return nil
+}
+
+// Services returns all registered services from the registry.
+func (s *ServiceGroup) Services() []*ServiceDescription {
+	res := make([]*ServiceDescription, 0, len(*s))
+	for _, v := range *s {
+		res = append(res, v)
+	}
+
+	return res
+}
+
 // Port provides an alias type for a TCP port.
 type Port uint16
 

--- a/driver/network/service_test.go
+++ b/driver/network/service_test.go
@@ -31,6 +31,27 @@ func TestGetFreePorts(t *testing.T) {
 		if err != nil {
 			t.Errorf("provided port %d is not free", port)
 		}
-		defer listener.Close()
+		t.Cleanup(func() {
+			_ = listener.Close()
+		})
 	}
+}
+
+func TestRegisterDuplicatedPortsForServices(t *testing.T) {
+	service := ServiceDescription{
+		Name:     "OperaPprof",
+		Port:     6060,
+		Protocol: "http",
+	}
+
+	serviceGroup := ServiceGroup{}
+
+	if err := serviceGroup.RegisterService(&service); err != nil {
+		t.Errorf("first registration must succeed")
+	}
+
+	if err := serviceGroup.RegisterService(&service); err == nil {
+		t.Errorf("first registration must fail")
+	}
+
 }


### PR DESCRIPTION
This PR makes service registration more robust by checking the ports are not the same - this feature is actually available in Docker, but not possible in in the golang API since port binding is propagated via Map - it can lead to a difficult to find error. 

It also tests the prometheus monitoring is available in the node