### PR TITLE
Add block-delay metric to report

### DIFF
--- a/analysis/report/single_eval_report.Rmd
+++ b/analysis/report/single_eval_report.Rmd
@@ -59,6 +59,38 @@ ggplot(data=data) +
 ```
 
 
+### Block Delay
+The following chart shows the time between the earliest reported completion time of block `n-1` and earliest reported completion time block `n` for block `n`.
+
+```{r block_delay_time, echo=FALSE, message=FALSE, fig.dim = figure_dimensions}
+data <- all_data %>%
+    # filter desired metric and columns
+    dplyr::filter(metric == "BlockCompletionTime") %>%
+    select(block, value) %>%
+    # convert values into numbers
+    mutate(value = as.numeric(value)) %>%
+    # find earliest time for each block
+    group_by(block) %>%
+    summarise(value = min(value)) %>%
+    # compute delta between consecutive blocks
+    arrange(block) %>%
+    mutate(delta = value - lag(value)) %>%
+    drop_na(delta)
+
+ggplot(data = data) +
+    # a horizontal line marking the 1s target
+    geom_hline(yintercept = 1, linetype = "dashed", color = "red") +
+    # the individual block delays
+    geom_point(aes(x = block, y = delta / 1e9)) +
+    # a interpolation line
+    geom_smooth(aes(x = block, y = delta / 1e9), se = FALSE) +
+    ggtitle("Block Delay") +                           # chart title
+    xlab("Block Height") +                             # x-axis title
+    ylab("Delay [s]") +                                # y-axis title
+    theme(plot.title = element_text(hjust = 0.5))      # center title
+```
+
+
 ## Network Metrics
 
 This section covers metrics that are network wide properties.

--- a/driver/monitoring/logreader.go
+++ b/driver/monitoring/logreader.go
@@ -2,6 +2,7 @@ package monitoring
 
 import (
 	"bufio"
+	"fmt"
 	"io"
 	"log"
 	"regexp"
@@ -58,8 +59,8 @@ func readBlocks(reader io.Reader, ch chan<- Block) error {
 
 // parseTime convert time from log format into Time type.
 func parseTime(str string) (time.Time, error) {
-
-	return time.Parse("[01-02|15:04:05.000]", str)
+	year := time.Now().Year()
+	return time.Parse("2006-[01-02|15:04:05.000]", fmt.Sprintf("%d-%s", year, str))
 }
 
 // parseBlock parses block information from the log line. It is expected the log line is well-formed.

--- a/driver/monitoring/logreader_test.go
+++ b/driver/monitoring/logreader_test.go
@@ -3,6 +3,7 @@ package monitoring
 import (
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestParseTime(t *testing.T) {
@@ -11,6 +12,9 @@ func TestParseTime(t *testing.T) {
 		t.Errorf("cannot parse: %s", err)
 	}
 
+	if got, want := tt.Year(), time.Now().Year(); got != want {
+		t.Errorf("wrong year parsed, want %d, got %d", want, got)
+	}
 	if val := tt.Month(); val != 5 {
 		t.Errorf("wrong time parsed: %d", val)
 	}

--- a/driver/monitoring/testdata.go
+++ b/driver/monitoring/testdata.go
@@ -1,6 +1,9 @@
 package monitoring
 
-import "time"
+import (
+	"fmt"
+	"time"
+)
 
 var (
 	Node1TestId = Node("A")
@@ -16,12 +19,13 @@ var (
 
 	Node3TestLog = "INFO [05-04|09:38:15.080] New block      index=1 id=2:1:247c79       gas_used=11 txs=10/0 age=7.392s t=5.686ms \n"
 
-	time1, _ = time.Parse("[01-02|15:04:05.000]", "[05-04|09:34:15.080]")
-	time2, _ = time.Parse("[01-02|15:04:05.000]", "[05-04|09:34:15.537]")
-	time3, _ = time.Parse("[01-02|15:04:05.000]", "[05-04|09:34:16.027]")
-	time4, _ = time.Parse("[01-02|15:04:05.000]", "[05-04|09:34:16.512]")
-	time5, _ = time.Parse("[01-02|15:04:05.000]", "[05-04|09:34:17.003]")
-	time6, _ = time.Parse("[01-02|15:04:05.000]", "[05-04|09:38:15.080]")
+	year     = time.Now().Year()
+	time1, _ = time.Parse("2006-[01-02|15:04:05.000]", fmt.Sprintf("%d-[05-04|09:34:15.080]", year))
+	time2, _ = time.Parse("2006-[01-02|15:04:05.000]", fmt.Sprintf("%d-[05-04|09:34:15.537]", year))
+	time3, _ = time.Parse("2006-[01-02|15:04:05.000]", fmt.Sprintf("%d-[05-04|09:34:16.027]", year))
+	time4, _ = time.Parse("2006-[01-02|15:04:05.000]", fmt.Sprintf("%d-[05-04|09:34:16.512]", year))
+	time5, _ = time.Parse("2006-[01-02|15:04:05.000]", fmt.Sprintf("%d-[05-04|09:34:17.003]", year))
+	time6, _ = time.Parse("2006-[01-02|15:04:05.000]", fmt.Sprintf("%d-[05-04|09:38:15.080]", year))
 
 	dur1, _ = time.ParseDuration("711.334µs")
 	dur2, _ = time.ParseDuration("1.579ms")

--- a/driver/norma/render.go
+++ b/driver/norma/render.go
@@ -27,7 +27,7 @@ func render(ctx *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	result, err := report.SingleEvalReport.Render(currentDir+"/"+input, currentDir)
+	result, err := report.SingleEvalReport.Render(input, currentDir)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Adds a plot of the time between block completion to the report.

Example plot:
![image](https://github.com/Fantom-foundation/Norma/assets/4097849/144ed717-96bd-4551-ba68-32fb9f1712fa)
