### PR TITLE
Add support for dumping node logs to monitoring output directory

### DIFF
--- a/driver/monitoring/monitor.go
+++ b/driver/monitoring/monitor.go
@@ -34,10 +34,14 @@ func NewMonitor(network driver.Network, config MonitorConfig) (*Monitor, error) 
 	if config.OutputDir == "" {
 		config.OutputDir = "."
 	}
+	dispatcher, err := NewNodeLogDispatcher(network, config.OutputDir)
+	if err != nil {
+		return nil, err
+	}
 	return &Monitor{
 		network:         network,
 		config:          config,
-		nodeLogProvider: NewNodeLogDispatcher(network),
+		nodeLogProvider: dispatcher,
 		sources:         map[string]source{},
 	}, nil
 }

--- a/driver/monitoring/node/block_metrics_test.go
+++ b/driver/monitoring/node/block_metrics_test.go
@@ -58,7 +58,10 @@ func TestIntegrateRegistryWithShutdownNodeMetrics(t *testing.T) {
 	}
 
 	source := NewBlockTimeSource(monitor)
-	reg := monitoring.NewNodeLogDispatcher(net)
+	reg, err := monitoring.NewNodeLogDispatcher(net, t.TempDir())
+	if err != nil {
+		t.Fatalf("failed to create node log dispatcher: %v", err)
+	}
 
 	// test the source is created later
 	time.Sleep(time.Second)

--- a/driver/monitoring/node_log_provider_test.go
+++ b/driver/monitoring/node_log_provider_test.go
@@ -2,6 +2,7 @@ package monitoring
 
 import (
 	"io"
+	"os"
 	"strings"
 	"sync"
 	"testing"
@@ -22,15 +23,19 @@ func TestRegisterLogParser(t *testing.T) {
 	node2.EXPECT().GetLabel().AnyTimes().Return(string(Node2TestId))
 	node3.EXPECT().GetLabel().AnyTimes().Return(string(Node3TestId))
 
-	node1.EXPECT().StreamLog().AnyTimes().Return(io.NopCloser(strings.NewReader(Node1TestLog)), nil)
-	node2.EXPECT().StreamLog().AnyTimes().Return(io.NopCloser(strings.NewReader(Node2TestLog)), nil)
-	node3.EXPECT().StreamLog().AnyTimes().Return(io.NopCloser(strings.NewReader(Node3TestLog)), nil)
+	node1.EXPECT().StreamLog().AnyTimes().DoAndReturn(func() (io.ReadCloser, error) { return io.NopCloser(strings.NewReader(Node1TestLog)), nil })
+	node2.EXPECT().StreamLog().AnyTimes().DoAndReturn(func() (io.ReadCloser, error) { return io.NopCloser(strings.NewReader(Node2TestLog)), nil })
+	node3.EXPECT().StreamLog().AnyTimes().DoAndReturn(func() (io.ReadCloser, error) { return io.NopCloser(strings.NewReader(Node3TestLog)), nil })
 
 	// simulate existing nodes
 	net.EXPECT().RegisterListener(gomock.Any())
 	net.EXPECT().GetActiveNodes().AnyTimes().Return([]driver.Node{node1, node2})
 
-	reg := NewNodeLogDispatcher(net)
+	dir := t.TempDir()
+	reg, err := NewNodeLogDispatcher(net, dir)
+	if err != nil {
+		t.Fatalf("failed to create log dispatcher: %v", err)
+	}
 	ch := make(chan Node, 10)
 	listener := &testBlockNodeListener{data: map[Node][]Block{}, ch: ch}
 	reg.RegisterLogListener(listener)
@@ -51,6 +56,27 @@ func TestRegisterLogParser(t *testing.T) {
 
 	if len(reg.getNodes()) != 3 {
 		t.Errorf("wrong number of iterations")
+	}
+
+	reg.WaitForLogsToBeConsumed()
+
+	// Check that log got copied to output files.
+	logs := []struct {
+		path, content string
+	}{
+		{dir + "/node_logs/A.log", Node1TestLog},
+		{dir + "/node_logs/B.log", Node2TestLog},
+		{dir + "/node_logs/C.log", Node3TestLog},
+	}
+	for _, log := range logs {
+		content, err := os.ReadFile(log.path)
+		if err != nil {
+			t.Errorf("failed to read log file: %v", err)
+			continue
+		}
+		if got, want := log.content, string(content); got != want {
+			t.Errorf("invalid log, wanted:\n%s\ngot:\n%s", want, got)
+		}
 	}
 }
 


### PR DESCRIPTION
This PR adds support for capturing all node logs in the monitoring directory for post-mortem analysis.

For simplicity, it requests an independent stream from of the output logs than the one used for parsing block progress information and forwards that stream to the target file.