### PR TITLE
uses already existing log dispatcher in the block metric test to clar…

### DIFF
--- a/driver/monitoring/node/block_metrics_test.go
+++ b/driver/monitoring/node/block_metrics_test.go
@@ -58,14 +58,7 @@ func TestIntegrateRegistryWithShutdownNodeMetrics(t *testing.T) {
 	}
 
 	source := NewBlockTimeSource(monitor)
-	reg, err := monitoring.NewNodeLogDispatcher(net, t.TempDir())
-	if err != nil {
-		t.Fatalf("failed to create node log dispatcher: %v", err)
-	}
-
-	// test the source is created later
-	time.Sleep(time.Second)
-	reg.RegisterLogListener(source)
+	reg := monitor.NodeLogProvider().(*monitoring.NodeLogDispatcher)
 
 	// add first node
 	reg.AfterNodeCreation(node1)


### PR DESCRIPTION
This PR only reuses the already existing Log dispatcher in the test instead of creating a new one.
It should make the test more clear