### PR TITLE
Kjezek/create source for prometheus api

### DIFF
--- a/driver/monitoring/monitor_test.go
+++ b/driver/monitoring/monitor_test.go
@@ -186,3 +186,25 @@ func TestMonitorIntegrationPrometheusLogReceived(t *testing.T) {
 
 	<-done
 }
+
+func TestMonitor_GetPrometheusLog(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	net := driver.NewMockNetwork(ctrl)
+
+	// simulate existing nodes
+	net.EXPECT().RegisterListener(gomock.Any()).AnyTimes()
+	net.EXPECT().GetActiveNodes().AnyTimes().Return([]driver.Node{})
+
+	outDir := t.TempDir()
+	monitor, err := NewMonitor(net, MonitorConfig{OutputDir: outDir})
+	if err != nil {
+		t.Fatalf("failed to create monitor instance: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = monitor.Shutdown()
+	})
+
+	if monitor.PrometheusLogProvider() == nil {
+		t.Errorf("prometheus log provider not configured")
+	}
+}

--- a/driver/monitoring/network/block_metrics_test.go
+++ b/driver/monitoring/network/block_metrics_test.go
@@ -45,6 +45,13 @@ func TestIntegrateRegistryWithShutdown(t *testing.T) {
 	node2.EXPECT().GetLabel().AnyTimes().Return(string(monitoring.Node2TestId))
 	node3.EXPECT().GetLabel().AnyTimes().Return(string(monitoring.Node3TestId))
 
+	urlA := driver.URL("A")
+	urlB := driver.URL("B")
+	urlC := driver.URL("C")
+	node1.EXPECT().GetServiceUrl(gomock.Any()).AnyTimes().Return(&urlA)
+	node2.EXPECT().GetServiceUrl(gomock.Any()).AnyTimes().Return(&urlB)
+	node3.EXPECT().GetServiceUrl(gomock.Any()).AnyTimes().Return(&urlC)
+
 	node1.EXPECT().StreamLog().AnyTimes().DoAndReturn(func() (io.ReadCloser, error) { return io.NopCloser(strings.NewReader(monitoring.Node1TestLog)), nil })
 	node2.EXPECT().StreamLog().AnyTimes().DoAndReturn(func() (io.ReadCloser, error) { return io.NopCloser(strings.NewReader(monitoring.Node2TestLog)), nil })
 	node3.EXPECT().StreamLog().AnyTimes().DoAndReturn(func() (io.ReadCloser, error) { return io.NopCloser(strings.NewReader(monitoring.Node3TestLog)), nil })

--- a/driver/monitoring/node/prom_log_source.go
+++ b/driver/monitoring/node/prom_log_source.go
@@ -1,0 +1,45 @@
+package nodemon
+
+import (
+	"fmt"
+	"github.com/Fantom-foundation/Norma/driver/monitoring"
+	"github.com/Fantom-foundation/Norma/driver/monitoring/utils"
+	"log"
+)
+
+// PromLogSource is a generic metric source for all metrics obtained via Prometheus API
+// from the Nodes. It is configured with the Prometheus metric of interest,
+// and it listens for incoming metric data of all running Nodes.
+type PromLogSource struct {
+	*utils.SyncedSeriesSource[monitoring.Node, monitoring.Time, float64]
+}
+
+// NewPromLogSource creates a new instance, which checks all network Nodes for Prometheus metrics.
+// The metric for which this instance is registered is captured and stored in time series separately for each Node.
+// This source will represent a new metric, which will have the same name as the metric to get from prometheus.
+// If the prometheus metric has quantile, the suffix '_q<num>', e.g. '_q0.999', will be added to the new metric name.
+func NewPromLogSource(monitor *monitoring.Monitor, prometheusMetric monitoring.PrometheusLogKey) *PromLogSource {
+	name := prometheusMetric.Name
+	if prometheusMetric.Quantile != monitoring.QuantileEmpty {
+		name = fmt.Sprintf("%s_q%s", name, prometheusMetric.Quantile)
+	}
+	metric := monitoring.Metric[monitoring.Node, monitoring.Series[monitoring.Time, float64]]{
+		Name:        name,
+		Description: fmt.Sprintf("Prometheus metric for %s", name),
+	}
+
+	p := &PromLogSource{
+		SyncedSeriesSource: utils.NewSyncedSeriesSource(metric),
+	}
+
+	monitor.PrometheusLogProvider().RegisterLogListener(prometheusMetric, p)
+
+	return p
+}
+
+func (p *PromLogSource) OnLog(node monitoring.Node, time monitoring.Time, value float64) {
+	series := p.GetOrAddSubject(node)
+	if err := series.Append(time, value); err != nil {
+		log.Printf("cannot add to series: %s", err)
+	}
+}

--- a/driver/monitoring/node/prom_log_source_test.go
+++ b/driver/monitoring/node/prom_log_source_test.go
@@ -1,0 +1,131 @@
+package nodemon
+
+import (
+	"fmt"
+	"github.com/Fantom-foundation/Norma/driver"
+	"github.com/Fantom-foundation/Norma/driver/docker"
+	"github.com/Fantom-foundation/Norma/driver/monitoring"
+	opera "github.com/Fantom-foundation/Norma/driver/node"
+	"github.com/golang/mock/gomock"
+	"golang.org/x/exp/slices"
+	"sort"
+	"testing"
+	"time"
+)
+
+func TestLogsAddedToSeries(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	net := driver.NewMockNetwork(ctrl)
+	net.EXPECT().RegisterListener(gomock.Any()).AnyTimes()
+	net.EXPECT().GetActiveNodes().AnyTimes().Return([]driver.Node{})
+
+	monitor, err := monitoring.NewMonitor(net, monitoring.MonitorConfig{OutputDir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("failed to initiate monitor: %v", err)
+	}
+
+	source := NewPromLogSource(monitor, monitoring.NewPrometheusNameKey("metric_name_a"))
+
+	requestedItems := 1000
+	expectedTimes := make([]monitoring.Time, 0, requestedItems)
+	expectedValues := make([]float64, 0, requestedItems)
+
+	for i := 0; i < requestedItems; i++ {
+		expectedTimes = append(expectedTimes, monitoring.Time(i))
+		expectedValues = append(expectedValues, float64(i))
+		source.OnLog("A", monitoring.Time(i), float64(i))
+		source.OnLog("B", monitoring.Time(2*i), float64(2*i))
+	}
+
+	// test subjects
+	want := []monitoring.Node{"A", "B"}
+	subjects := source.GetSubjects()
+	sort.Slice(subjects, func(i, j int) bool { return subjects[i] < subjects[j] })
+	if !slices.Equal(subjects, want) {
+		t.Errorf("invalid list of subjects, wanted %v, got %v", want, subjects)
+	}
+
+	for i, multiplier := range []int{1, 2} {
+		t.Run(fmt.Sprintf("subject %s", want[i]), func(t *testing.T) {
+			// test series content
+			series, exists := source.GetData(want[i])
+			if !exists {
+				t.Errorf("series should exist")
+			}
+			seriesRange := series.GetRange(monitoring.Time(0), monitoring.Time(2*requestedItems))
+			if got, want := len(seriesRange), requestedItems; got != want {
+				t.Errorf("unexpected series size: %d != %d", got, want)
+			}
+			for i, datapoint := range seriesRange {
+				if got, want := datapoint.Position, monitoring.Time(i*multiplier); got != want {
+					t.Errorf("expected position does not match: %d != %d", got, want)
+				}
+				if got, want := int(datapoint.Value), i*multiplier; got != want {
+					t.Errorf("expected position does not match: %d != %d", got, want)
+				}
+			}
+		})
+	}
+}
+
+func TestLogsIntegrationGetRealMetric(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	net := driver.NewMockNetwork(ctrl)
+
+	client, err := docker.NewClient()
+	if err != nil {
+		t.Fatalf("failed to create a docker client: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = client.Close()
+	})
+	node, err := opera.StartOperaDockerNode(client, nil, &opera.OperaNodeConfig{
+		Label:         "test",
+		NetworkConfig: &driver.NetworkConfig{NumberOfValidators: 1},
+	})
+	if err != nil {
+		t.Fatalf("failed to create an Opera node on Docker: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = node.Cleanup()
+	})
+
+	// simulate existing nodes
+	net.EXPECT().RegisterListener(gomock.Any()).AnyTimes()
+	net.EXPECT().GetActiveNodes().AnyTimes().Return([]driver.Node{node})
+
+	outDir := t.TempDir()
+	monitor, err := monitoring.NewMonitor(net, monitoring.MonitorConfig{OutputDir: outDir})
+	if err != nil {
+		t.Fatalf("failed to create monitor instance: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = monitor.Shutdown()
+	})
+
+	for _, metricKeys := range []monitoring.PrometheusLogKey{
+		monitoring.NewPrometheusKey("chain_execution", monitoring.Quantile05),
+		monitoring.NewPrometheusNameKey("chain_execution_count")} {
+
+		// wait for the metric to arrive for some time
+		source := NewPromLogSource(monitor, metricKeys)
+		var found bool
+		for i := 0; i < 100; i++ {
+			series, exists := source.GetData("test")
+			if exists {
+				datapoint := series.GetLatest()
+				if datapoint != nil {
+					found = datapoint.Position > 0
+					break
+				}
+			}
+			time.Sleep(100 * time.Millisecond)
+		}
+
+		if !found {
+			t.Errorf("Metric data not arrived within give time for: %s", metricKeys.Name)
+		}
+	}
+}

--- a/driver/monitoring/prom_log_provider.go
+++ b/driver/monitoring/prom_log_provider.go
@@ -27,13 +27,37 @@ type TimeLogListener interface {
 // For this reason, the key is composed of the name and quantile only.
 // The quantile is set to empty when it is not applicable.
 type PrometheusLogKey struct {
-	name     string
-	quantile string
+	Name     string
+	Quantile Quantile
 }
 
-// NewPrometheusNameKey composes the key using the name of the metric only. The quantile is set to zero.
+func (p PrometheusLogKey) String() string {
+	if p.Quantile == QuantileEmpty {
+		return fmt.Sprintf("%s", p.Name)
+	} else {
+		return fmt.Sprintf("%s (q: %s)", p.Name, p.Quantile)
+	}
+}
+
+// Quantile is a type representing quantile for a summary metric.
+type Quantile string
+
+const (
+	Quantile05    Quantile = "0.5"
+	Quantile09             = "0.9"
+	Quantile099            = "0.99"
+	Quantile0999           = "0.999"
+	QuantileEmpty          = ""
+)
+
+// NewPrometheusKey composes the key using the name of the metric and quantile
+func NewPrometheusKey(name string, quantile Quantile) PrometheusLogKey {
+	return PrometheusLogKey{Name: name, Quantile: quantile}
+}
+
+// NewPrometheusNameKey composes the key using the name of the metric only. The quantile is set to empty.
 func NewPrometheusNameKey(name string) PrometheusLogKey {
-	return PrometheusLogKey{name: name}
+	return PrometheusLogKey{Name: name, Quantile: QuantileEmpty}
 }
 
 // PrometheusLogProvider is an interface for registering listeners that will be notified about incoming

--- a/driver/monitoring/prom_log_provider_test.go
+++ b/driver/monitoring/prom_log_provider_test.go
@@ -299,6 +299,15 @@ func TestLogsCannotAddListenerAfterShutdown(t *testing.T) {
 	time.Sleep(2 * time.Second)
 }
 
+func TestParseQuantileEnum(t *testing.T) {
+	if Quantile099 != Quantile("0.99") {
+		t.Errorf("quantiles do not match")
+	}
+	if Quantile05 != Quantile("0.5") {
+		t.Errorf("quantiles do not match")
+	}
+}
+
 var (
 	testData = map[driver.URL][]PrometheusLogValue{
 		"A": {

--- a/driver/monitoring/promlogreader.go
+++ b/driver/monitoring/promlogreader.go
@@ -24,9 +24,9 @@ type PrometheusLogValue struct {
 
 func (p PrometheusLogValue) String() string {
 	if p.metricType == summaryPrometheusMetricType {
-		return fmt.Sprintf("%s_%s: %.2f (q: %s)", p.name, p.metricType, p.value, p.quantile)
+		return fmt.Sprintf("%s_%s: %.2f (q: %s)", p.Name, p.metricType, p.value, p.Quantile)
 	} else {
-		return fmt.Sprintf("%s_%s: %.2f", p.name, p.metricType, p.value)
+		return fmt.Sprintf("%s_%s: %.2f", p.Name, p.metricType, p.value)
 	}
 }
 
@@ -68,7 +68,7 @@ func ParsePrometheusLogReader(reader io.Reader) ([]PrometheusLogValue, error) {
 				currentName = tokens[2]
 				nextType = PrometheusMetricType(tokens[3])
 			} else if tokens[0] == currentName {
-				val := PrometheusLogValue{PrometheusLogKey: PrometheusLogKey{name: currentName}, metricType: nextType}
+				val := PrometheusLogValue{PrometheusLogKey: PrometheusLogKey{Name: currentName}, metricType: nextType}
 				if err := fillValue(tokens, &val); err != nil {
 					errs = append(errs, err)
 				} else {
@@ -96,7 +96,7 @@ func fillValue(tokens []string, dest *PrometheusLogValue) error {
 	// - metric_name metric_value
 	// - metric_name quantile_value metric_value
 	if len(tokens) >= 3 && quantileReg.MatchString(tokens[1]) {
-		dest.quantile = strings.Split(tokens[1], "\"")[1]
+		dest.Quantile = Quantile(strings.Split(tokens[1], "\"")[1])
 		valueStr = tokens[2]
 	} else {
 		valueStr = tokens[1]


### PR DESCRIPTION
This PR creates Metric source that obtains Prometheus metric and wraps it into Norma metric.

The metric of interest must be defined by its name, and the metric with the same name is obtained from Prometheus. 

Since Prometheus can provide some of the metrics divided into quantiles, the requested quantile must be provided in Norma metrics as well. It means that getting `N` quantiles from Prometheus requires creation of `N` Norma metrics .