### PR TITLE
makes RPC dial more resilient by attempting more times and panicing w…

### DIFF
--- a/driver/network/rpc/rpc_pool_test.go
+++ b/driver/network/rpc/rpc_pool_test.go
@@ -1,0 +1,25 @@
+package rpc
+
+import (
+	"github.com/ethereum/go-ethereum/core/types"
+	"testing"
+	"time"
+)
+
+func TestRetryRpcReturnGracefully(t *testing.T) {
+	t.Parallel()
+
+	txs := make(chan *types.Transaction)
+
+	start := time.Now()
+	err := runRpcSenderLoop("wrong", 6, txs)
+
+	// we expect error, but should not panic
+	if err == nil {
+		t.Errorf("method was expected to fail")
+	}
+
+	if got, want := time.Now().Sub(start).Seconds(), float64(5); got < want {
+		t.Errorf("RPC should be attempted around 6s, was: %f < %f", got, want)
+	}
+}


### PR DESCRIPTION
I was getting often RPC connection error followed by panic. It seems the problem was that when the Node is created, its RPC service does not have to be necessarily ready.  This PR fixes it by
* trying connection many times
* if connection fails after certain number of attempts, it does not panic


Error I used to get when running for instance just the small.yaml experiment: 
```

2023/07/03 16:22:00 failed to open RPC connection; read tcp [::1]:56725->[::1]:56613: read: connection reset by peer
2023/07/03 16:22:00 failed to open RPC connection; read tcp [::1]:56722->[::1]:56613: read: connection reset by peer
2023/07/03 16:22:00 failed to open RPC connection; read tcp [::1]:56723->[::1]:56613: read: connection reset by peer
2023/07/03 16:22:00 failed to open RPC connection; read tcp [::1]:56724->[::1]:56613: read: connection reset by peer
2023/07/03 16:22:00 failed to open RPC connection; read tcp [::1]:56727->[::1]:56613: read: connection reset by peer
2023/07/03 16:22:00 failed to open RPC connection; read tcp [::1]:56726->[::1]:56613: read: connection reset by peer
2023/07/03 16:22:00 failed to open RPC connection; read tcp [::1]:56730->[::1]:56613: read: connection reset by peer
2023/07/03 16:22:00 failed to open RPC connection; read tcp [::1]:56729->[::1]:56613: read: connection reset by peer
2023/07/03 16:22:00 failed to open RPC connection; read tcp [::1]:56728->[::1]:56613: read: connection reset by peer
2023/07/03 16:22:00 failed to open RPC connection; read tcp [::1]:56721->[::1]:56613: read: connection reset by peer
2023/07/03 16:22:00 Nodes: 4, block heights: [6 6 N/A 6], tx/s: [6000 3000 12.345679], txs: 6, gas: 218283, block processing: [1.602ms 1.217ms 5.038ms]
2023/07/03 16:22:01 Nodes: 4, block heights: [6 6 1 6], tx/s: [6000 3000 3000 12.345679], txs: 6, gas: 218283, block processing: [1.602ms 1.217ms 1.271ms 5.038ms]
2023/07/03 16:22:02 Nodes: 4, block heights: [6 6 6 6], tx/s: [6000 3000 3000 12.345679], txs: 6, gas: 218283, block processing: [1.602ms 1.217ms 1.271ms 5.038ms]
2023/07/03 16:22:03 Nodes: 4, block heights: [6 6 6 6], tx/s: [6000 3000 3000 12.345679], txs: 6, gas: 218283, block processing: [1.602ms 1.217ms 1.271ms 5.038ms]
2023/07/03 16:22:04 Nodes: 4, block heights: [6 6 6 6], tx/s: [6000 3000 3000 12.345679], txs: 6, gas: 218283, block processing: [1.602ms 1.217ms 1.271ms 5.038ms]
2023/07/03 16:22:05 Nodes: 4, block heights: [6 6 6 6], tx/s: [6000 3000 3000 12.345679], txs: 6, gas: 218283, block processing: [1.602ms 1.217ms 1.271ms 5.038ms]
2023/07/03 16:22:06 processing 'starting app counter-0' at time 10.0 ...
2023/07/03 16:22:06 Nodes: 4, block heights: [7 6 7 7], tx/s: [11.904762 12.121212 12.048193 12.121212], txs: 2, gas: 102828, block processing: [2.726ms 1.094ms 1.179ms 1.276ms]
panic: runtime error: invalid memory address or nil pointer dereference
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x1006bd828]

goroutine 203 [running]:
github.com/ethereum/go-ethereum/ethclient.(*Client).Close(0x140008d0cf8?)
	/Users/kjezek/go/pkg/mod/github.com/ethereum/go-ethereum@v1.11.6/ethclient/ethclient.go:58 +0x18
panic({0x100846cc0, 0x100c75de0})
	/usr/local/go/src/runtime/panic.go:884 +0x204
github.com/ethereum/go-ethereum/ethclient.(*Client).SendTransaction(0x0, {0x100904590, 0x140000b6588}, 0x0?)
	/Users/kjezek/go/pkg/mod/github.com/ethereum/go-ethereum@v1.11.6/ethclient/ethclient.go:581 +0x194
github.com/Fantom-foundation/Norma/driver/network/rpc.runRpcSenderLoop({0x140000bf740?, 0x0?}, 0x0?)
	/Users/kjezek/fantom/Norma/driver/network/rpc/rpc_pool.go:54 +0xec
created by github.com/Fantom-foundation/Norma/driver/network/rpc.RpcWorkerPool.AfterNodeCreation
	/Users/kjezek/fantom/Norma/driver/network/rpc/rpc_pool.go:33 +0x58
``` 