### PR TITLE
Fix timeout in prometheus start

### DIFF
--- a/driver/monitoring/prometheus/prometheus.go
+++ b/driver/monitoring/prometheus/prometheus.go
@@ -64,9 +64,9 @@ func Start(net driver.Network, dn *docker.Network) (*Prometheus, error) {
 		return nil, err
 	}
 
-	// wait until the prometheus inside the Container is ready. (15 seconds max)
+	// wait until the prometheus inside the Container is ready. (30 seconds max)
 	// this is necessary for SIGHUP signal to be delivered correctly
-	for i := 0; i < 15; i++ {
+	for i := 0; i < 30; i++ {
 		// send get request to `<url>/-/ready` which contains status, from prometheus docs:
 		// "The readiness endpoint returns a 200 OK HTTP status code if Prometheus is ready to serve traffic."
 		resp, err := http.Get(prometheus.GetUrl() + "/-/ready")


### PR DESCRIPTION
Prometheus tests are flaky - timeouts while waiting until Prometheus becomes available:
```
--- FAIL: TestNodeCanBeAdded (13.10s)
    prometheus_test.go:94: error: prometheus instance is not ready
FAIL
```
https://github.com/Fantom-foundation/Norma/actions/runs/5443778687/jobs/9900743833#step:11:23