### PR TITLE
Remove legend from per-account plot to avoid overloading the chart

### DIFF
--- a/analysis/report/single_eval_report.Rmd
+++ b/analysis/report/single_eval_report.Rmd
@@ -317,17 +317,20 @@ ggplot() +
 ```
 
 
-The following chart shows the cummulative number of transactions send per account.
+The following chart shows the cummulative number of transactions send per account  (legend omitted for clarity).
 
 ```{r sent_transactions_per_app, echo=FALSE, message=FALSE, fig.dim = figure_dimensions}
 data <- all_data %>%
     dplyr::filter(metric == "SentTransactions") %>%  # filter metric
-    mutate(date = as_datetime(as.numeric(time)/1e9)) %>%   # UNIX time to date
+    mutate(date = as_datetime(as.numeric(time) / 1e9)) %>%   # UNIX time to date
     mutate(value = as.numeric(value)) %>%              # convert value to int
     mutate(account = paste(app, "_", workers))         # add an account name
 
-ggplot(data=data) +
-    geom_line(aes(x=date, y=value, group=account, colour = factor(account))) +
+ggplot(data = data) +
+    geom_line(
+        aes(x = date, y = value, group = account, colour = factor(account)),
+        show.legend = FALSE
+    ) +
     ggtitle("Sent Transactions per Account") +         # chart title
     xlab("Time") +                                     # x-axis title
     ylab("Total Number of Transactions") +             # y-axis title
@@ -336,15 +339,18 @@ ggplot(data=data) +
     scale_x_datetime(date_labels = "%c")               # format date labels
 ```
 
-The following chart shows the send-rate of individual accounts.
+The following chart shows the send-rate of individual accounts (legend omitted for clarity).
 
 ```{r send_rate_per_account, echo=FALSE, message=FALSE, fig.dim = figure_dimensions}
 sent_rate <- sent_rate %>%
-    mutate(date = as_datetime(as.numeric(time)/1e9)) %>%
+    mutate(date = as_datetime(as.numeric(time) / 1e9)) %>%
     mutate(account = paste(app, "_", workers))         # add an account name
 
-ggplot() +
-    geom_line(data=sent_rate, aes(x=date, y=rate, group=account, colour = factor(account))) +
+ggplot(data = sent_rate) +
+    geom_line(
+        aes(x = date, y = rate, group = account, colour = factor(account)),
+        show.legend = FALSE
+    ) +
     ggtitle("Sent Rate of Transactions per Account") +         # chart title
     xlab("Time") +                                     # x-axis title
     ylab("Rate [Tx/s]") +             # y-axis title


### PR DESCRIPTION
With a larger number of accounts per application, the legend of those charts tends to fill up the entire space. 

Since those charts are mainly intended to show the uniform usage of accounts in applications, the need for distinguishing individual accounts is not given. Thus, hiding the legends does not reduce the utility of those charts.

Before:
![image](https://github.com/Fantom-foundation/Norma/assets/4097849/5c6be6ca-c76b-49c2-adf2-cb32f5c229fa)

After:
![image](https://github.com/Fantom-foundation/Norma/assets/4097849/5ace8bd8-c053-4edc-8a31-9e4086f7e092)
