### PR TITLE
Kjezek/resilient start rpc

### DIFF
--- a/driver/docker/docker.go
+++ b/driver/docker/docker.go
@@ -162,7 +162,9 @@ func (c *Client) Start(config *ContainerConfig) (*Container, error) {
 		}
 	}
 
-	if err := c.cli.ContainerStart(context.Background(), resp.ID, types.ContainerStartOptions{}); err != nil {
+	if err := network.Retry(network.DefaultRetryAttempts, 1*time.Second, func() error {
+		return c.cli.ContainerStart(context.Background(), resp.ID, types.ContainerStartOptions{})
+	}); err != nil {
 		return nil, err
 	}
 

--- a/driver/monitoring/node_log_provider_test.go
+++ b/driver/monitoring/node_log_provider_test.go
@@ -49,6 +49,8 @@ func TestRegisterLogParser(t *testing.T) {
 	reg.AfterNodeCreation(node2)
 	reg.AfterNodeCreation(node3)
 
+	reg.WaitForLogsToBeConsumed()
+
 	// drain 3 nodes from the channel
 	for _, node := range []Node{<-ch, <-ch, <-ch} {
 		got := listener.getBlocks(node)
@@ -63,8 +65,6 @@ func TestRegisterLogParser(t *testing.T) {
 	if len(reg.getNodes()) != 3 {
 		t.Errorf("wrong number of iterations")
 	}
-
-	reg.WaitForLogsToBeConsumed()
 
 	// Check that log got copied to output files.
 	logs := []struct {

--- a/driver/network/local/local.go
+++ b/driver/network/local/local.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/Fantom-foundation/Norma/driver/network"
 	"log"
 	"math/rand"
 	"sync"
+	"time"
 
 	"github.com/Fantom-foundation/Norma/driver/network/rpc"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -184,7 +186,9 @@ func (n *LocalNetwork) DialRandomRpc() (app.RpcClient, error) {
 	if rpcUrl == nil {
 		return nil, fmt.Errorf("websocket service is not available")
 	}
-	return ethclient.Dial(string(*rpcUrl))
+	return network.RetryReturn(network.DefaultRetryAttempts, 1*time.Second, func() (*ethclient.Client, error) {
+		return ethclient.Dial(string(*rpcUrl))
+	})
 }
 
 // reasureAccountPrivateKey is an account with tokens that can be used to
@@ -247,7 +251,9 @@ func (n *LocalNetwork) CreateApplication(config *driver.ApplicationConfig) (driv
 		return nil, fmt.Errorf("primary node is not running an RPC server")
 	}
 
-	rpcClient, err := ethclient.Dial(string(*rpcUrl))
+	rpcClient, err := network.RetryReturn(network.DefaultRetryAttempts, 1*time.Second, func() (*ethclient.Client, error) {
+		return ethclient.Dial(string(*rpcUrl))
+	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to RPC to initialize the application; %v", err)
 	}

--- a/driver/network/local/local_test.go
+++ b/driver/network/local/local_test.go
@@ -2,10 +2,9 @@ package local
 
 import (
 	"fmt"
-	"testing"
-
 	"github.com/Fantom-foundation/Norma/driver"
 	"github.com/golang/mock/gomock"
+	"testing"
 )
 
 func TestLocalNetworkIsNetwork(t *testing.T) {
@@ -24,7 +23,9 @@ func TestLocalNetwork_CanStartNodesAndShutThemDown(t *testing.T) {
 			if err != nil {
 				t.Fatalf("failed to create new local network: %v", err)
 			}
-			t.Cleanup(func() { net.Shutdown() })
+			t.Cleanup(func() {
+				_ = net.Shutdown()
+			})
 
 			nodes := []driver.Node{}
 			for i := 0; i < N; i++ {
@@ -33,8 +34,8 @@ func TestLocalNetwork_CanStartNodesAndShutThemDown(t *testing.T) {
 				})
 				if err != nil {
 					t.Errorf("failed to create node: %v", err)
+					continue
 				}
-				defer node.Cleanup()
 				nodes = append(nodes, node)
 			}
 
@@ -65,7 +66,9 @@ func TestLocalNetwork_CanStartApplicatonsAndShutThemDown(t *testing.T) {
 			if err != nil {
 				t.Fatalf("failed to create new local network: %v", err)
 			}
-			t.Cleanup(func() { net.Shutdown() })
+			t.Cleanup(func() {
+				_ = net.Shutdown()
+			})
 
 			apps := []driver.Application{}
 			for i := 0; i < N; i++ {
@@ -74,13 +77,13 @@ func TestLocalNetwork_CanStartApplicatonsAndShutThemDown(t *testing.T) {
 				})
 				if err != nil {
 					t.Errorf("failed to create app: %v", err)
+					continue
 				}
 
 				if got, want := app.Config().Name, fmt.Sprintf("T-%d", i); got != want {
 					t.Errorf("app configurion not propagated: %v != %v", got, want)
 				}
 
-				defer app.Stop()
 				apps = append(apps, app)
 			}
 
@@ -108,7 +111,9 @@ func TestLocalNetwork_CanPerformNetworkShutdown(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create new local network: %v", err)
 	}
-	t.Cleanup(func() { net.Shutdown() })
+	t.Cleanup(func() {
+		_ = net.Shutdown()
+	})
 
 	for i := 0; i < N; i++ {
 		_, err := net.CreateNode(&driver.NodeConfig{
@@ -144,7 +149,9 @@ func TestLocalNetwork_CanRunWithMultipleValidators(t *testing.T) {
 			if err != nil {
 				t.Fatalf("failed to create new local network: %v", err)
 			}
-			t.Cleanup(func() { net.Shutdown() })
+			t.Cleanup(func() {
+				_ = net.Shutdown()
+			})
 
 			app, err := net.CreateApplication(&driver.ApplicationConfig{
 				Name: "TestApp",
@@ -152,7 +159,6 @@ func TestLocalNetwork_CanRunWithMultipleValidators(t *testing.T) {
 			if err != nil {
 				t.Fatalf("failed to create app: %v", err)
 			}
-			defer app.Stop()
 
 			if err := app.Start(); err != nil {
 				t.Errorf("failed to start app: %v", err)
@@ -175,7 +181,9 @@ func TestLocalNetwork_NotifiesListenersOnNodeStartup(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create new local network: %v", err)
 	}
-	t.Cleanup(func() { net.Shutdown() })
+	t.Cleanup(func() {
+		_ = net.Shutdown()
+	})
 
 	activeNodes := net.GetActiveNodes()
 	if got, want := len(activeNodes), config.NumberOfValidators; got != want {
@@ -206,7 +214,9 @@ func TestLocalNetwork_NotifiesListenersOnAppStartup(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create new local network: %v", err)
 	}
-	t.Cleanup(func() { net.Shutdown() })
+	t.Cleanup(func() {
+		_ = net.Shutdown()
+	})
 
 	net.RegisterListener(listener)
 	listener.EXPECT().AfterApplicationCreation(gomock.Any())
@@ -230,7 +240,9 @@ func TestLocalNetwork_CanRemoveNode(t *testing.T) {
 			if err != nil {
 				t.Fatalf("failed to create new local network: %v", err)
 			}
-			t.Cleanup(func() { _ = net.Shutdown() })
+			t.Cleanup(func() {
+				_ = net.Shutdown()
+			})
 
 			nodes := make([]driver.Node, 0, N)
 			for i := 0; i < N; i++ {

--- a/driver/network/service.go
+++ b/driver/network/service.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"strconv"
 	"strings"
+	"time"
 )
 
 // ServiceDescription is
@@ -96,4 +97,36 @@ func GetFreePorts(num int) ([]Port, error) {
 		}
 	}
 	return ports, nil
+}
+
+const DefaultRetryAttempts = 180
+
+// RetryReturn executes the input function until it produces no error.
+// It however executes only the configured number of times with the configured
+// delay between attempts. If the execution is not successful since,
+// the execution returns the last error.
+// When execution is successful, the execution result is returned from this method.
+func RetryReturn[Out any](numAttempts int, delay time.Duration, do func() (Out, error)) (Out, error) {
+	var out Out
+	var err error
+	for i := 0; i < numAttempts; i++ {
+		out, err = do()
+		if err == nil {
+			break
+		}
+		time.Sleep(delay)
+	}
+	return out, err
+}
+
+// Retry executes the input function until it produces no error.
+// It however executes only the configured number of times with the configured
+// delay between attempts. If the execution is not successful since,
+// the execution returns the last error.
+func Retry(numAttempts int, delay time.Duration, do func() error) error {
+	_, err := RetryReturn(numAttempts, delay, func() (*int, error) {
+		err := do()
+		return nil, err
+	})
+	return err
 }

--- a/driver/network/service_test.go
+++ b/driver/network/service_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net"
 	"testing"
+	"time"
 )
 
 func TestGetFreePort(t *testing.T) {
@@ -54,4 +55,26 @@ func TestRegisterDuplicatedPortsForServices(t *testing.T) {
 		t.Errorf("first registration must fail")
 	}
 
+}
+
+func TestRetry(t *testing.T) {
+	t.Parallel()
+
+	var count int
+	err := Retry(5, 1*time.Millisecond, func() error {
+		count++
+		if count >= 5 {
+			return nil
+		} else {
+			return fmt.Errorf("no time to end yet")
+		}
+	})
+
+	if err != nil {
+		t.Errorf("Retry should success eventually")
+	}
+
+	if got, want := count, 5; got < want {
+		t.Errorf("Retry finished early: %d < %d", got, want)
+	}
 }

--- a/driver/node/opera_test.go
+++ b/driver/node/opera_test.go
@@ -31,6 +31,10 @@ func TestOperaNode_StartAndStop(t *testing.T) {
 		Label:         "test",
 		NetworkConfig: &driver.NetworkConfig{NumberOfValidators: 1},
 	})
+	t.Cleanup(func() {
+		_ = node.Cleanup()
+	})
+
 	if err != nil {
 		t.Fatalf("failed to create an Opera node on Docker: %v", err)
 	}
@@ -54,6 +58,10 @@ func TestOperaNode_RpcServiceIsReadyAfterStartup(t *testing.T) {
 		Label:         "test",
 		NetworkConfig: &driver.NetworkConfig{NumberOfValidators: 1},
 	})
+	t.Cleanup(func() {
+		_ = node.Cleanup()
+	})
+
 	if err != nil {
 		t.Fatalf("failed to create an Opera node on Docker: %v", err)
 	}
@@ -62,9 +70,6 @@ func TestOperaNode_RpcServiceIsReadyAfterStartup(t *testing.T) {
 	})
 	if id, err := node.GetNodeID(); err != nil || len(id) == 0 {
 		t.Errorf("failed to fetch NodeID from Opera node: '%v', err: %v", id, err)
-	}
-	if err = node.host.Stop(); err != nil {
-		t.Errorf("failed to stop Opera node: %v", err)
 	}
 }
 

--- a/load/app/app_test.go
+++ b/load/app/app_test.go
@@ -2,6 +2,7 @@ package app_test
 
 import (
 	"context"
+	"github.com/Fantom-foundation/Norma/driver/network"
 	"testing"
 	"time"
 
@@ -28,7 +29,10 @@ func TestGenerators(t *testing.T) {
 		t.Fatal("websocket service is not available")
 	}
 
-	rpcClient, err := ethclient.Dial(string(*rpcUrl))
+	rpcClient, err := network.RetryReturn(network.DefaultRetryAttempts, 1*time.Second, func() (*ethclient.Client, error) {
+		return ethclient.Dial(string(*rpcUrl))
+	})
+
 	if err != nil {
 		t.Fatal("unable to connect the the rpc")
 	}

--- a/load/controller/rpc_test.go
+++ b/load/controller/rpc_test.go
@@ -2,6 +2,7 @@ package controller_test
 
 import (
 	"context"
+	"github.com/Fantom-foundation/Norma/driver/network"
 	"testing"
 	"time"
 
@@ -30,7 +31,9 @@ func TestTrafficGenerating(t *testing.T) {
 		t.Fatal("websocket service is not available")
 	}
 
-	rpcClient, err := ethclient.Dial(string(*rpcUrl))
+	rpcClient, err := network.RetryReturn(network.DefaultRetryAttempts, 1*time.Second, func() (*ethclient.Client, error) {
+		return ethclient.Dial(string(*rpcUrl))
+	})
 	if err != nil {
 		t.Fatal("unable to connect the the rpc")
 	}


### PR DESCRIPTION
This PR tries to make Norma more resilient mainly in areas where it calls RPC.
Basically unsuccessful calls are repeated more times to prevent adhoc network/communication or late start errors. 

I run 30+ times on the server and all tests passed.

I am still sometimes getting: 
```
--- FAIL: TestLocalNetwork_CanRunWithMultipleValidators (0.00s)
    --- FAIL: TestLocalNetwork_CanRunWithMultipleValidators/num_validators=3 (205.44s)
        local_test.go:150: failed to create new local network: failed to start opera docker; Error response from daemon: driver failed programming external connectivity on endpoint crazy_mirzakhani (856444f61c3ec8323d1c5165de0d7dc6a334d05d33847a2ad7d7247cb20705c7): listen tcp4 0.0.0.0:56544: bind: address already in use
```
        
 locally (macOS), could not get it working unfortunately. 