### PR TITLE
Switch from frequency to interval based traffic shaping

### DIFF
--- a/load/controller/controller_test.go
+++ b/load/controller/controller_test.go
@@ -1,0 +1,134 @@
+package controller
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/Fantom-foundation/Norma/driver"
+	"github.com/Fantom-foundation/Norma/load/app"
+	"github.com/Fantom-foundation/Norma/load/shaper"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/golang/mock/gomock"
+)
+
+func TestLoadGeneration_CanRealizeConstantTrafficShape(t *testing.T) {
+
+	rates := []int{
+		10, 20, 50, 100, 200, 500, 1000, 2000, 5000,
+	}
+
+	for _, rate := range rates {
+		t.Run(fmt.Sprintf("linear rate %v", rate), func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			net := driver.NewMockNetwork(ctrl)
+			rpcClient := app.NewMockRpcClient(ctrl)
+			application := app.NewMockApplication(ctrl)
+			user := app.NewMockUser(ctrl)
+			transaction := types.Transaction{}
+
+			check := NewRateCheck(float64(rate))
+			var count atomic.Int32
+			net.EXPECT().DialRandomRpc().AnyTimes().Return(rpcClient, nil)
+			net.EXPECT().SendTransaction(gomock.Any()).AnyTimes().Do(func(x any) {
+				check.NewEvent()
+				count.Add(1)
+			})
+
+			rpcClient.EXPECT().Close().AnyTimes().Return()
+
+			application.EXPECT().CreateUser(gomock.Any()).AnyTimes().Return(user, nil)
+			application.EXPECT().WaitUntilApplicationIsDeployed(gomock.Any()).Return(nil)
+
+			user.EXPECT().GenerateTx().AnyTimes().Return(&transaction, nil)
+
+			shaper := shaper.NewConstantShaper(float64(rate))
+			controller, err := NewAppController(application, shaper, 100, net)
+			if err != nil {
+				t.Fatalf("failed to create app controller: %v", err)
+			}
+
+			ctx, cancel := context.WithCancel(context.Background())
+			done := make(chan bool)
+			go func() {
+				defer close(done)
+				controller.Run(ctx)
+			}()
+
+			time.Sleep(time.Second)
+			cancel()
+			<-done
+
+			// Check that the total number of processed messages is close to what is expected.
+			got := float32(count.Load())
+			want := float32(rate)
+			if math.Abs(float64(got-want)) > math.Max(float64(want*0.02), 2.0) {
+				t.Errorf("invalid number of produced messages, wanted ~%.0f, got %.0f", want, got)
+			}
+
+			// Check that during the execution the expected rate was within limits.
+			if got, want := check.GetNumberOfUnderflows(), 0; got != want {
+				t.Errorf("encountered %d times where messages have been produced too fast", got)
+			}
+			if got, want := check.GetNumberOfOverflows(), 0; got != want {
+				t.Errorf("encountered %d times where messages have been produced too slow", got)
+			}
+		})
+	}
+}
+
+type RateCheck struct {
+	underflows atomic.Int32
+	overflows  atomic.Int32
+	mu         sync.Mutex
+	level      float64
+	last       time.Time
+	rate       float64
+	tolerance  float64
+}
+
+func NewRateCheck(rate float64) *RateCheck {
+	return &RateCheck{
+		rate:      rate,
+		tolerance: math.Max(rate*0.1, 2.0),
+	}
+}
+
+func (c *RateCheck) NewEvent() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	now := time.Now()
+
+	if c.last.IsZero() {
+		c.last = now
+		return
+	}
+
+	delta := now.Sub(c.last)
+
+	c.level += delta.Seconds() * c.rate
+
+	if c.level > c.tolerance {
+		c.overflows.Add(1)
+	}
+
+	c.level -= 1
+	if c.level < -c.tolerance {
+		c.underflows.Add(1)
+	}
+
+	c.last = now
+}
+
+func (c *RateCheck) GetNumberOfUnderflows() int {
+	return int(c.underflows.Load())
+}
+
+func (c *RateCheck) GetNumberOfOverflows() int {
+	return int(c.overflows.Load())
+}

--- a/load/controller/rpc_test.go
+++ b/load/controller/rpc_test.go
@@ -85,7 +85,8 @@ func TestTrafficGenerating(t *testing.T) {
 
 	// in optimal case should be generated 30 txs per second
 	// as a tolerance for slow CI we require at least 20 txs
-	if sum < 20 || sum > 30 {
+	// and at most 40, since timing is not perfect.
+	if sum < 20 || sum > 40 {
 		t.Errorf("unexpected amount of generated txs: %d", sum)
 	}
 }

--- a/load/shaper/constant.go
+++ b/load/shaper/constant.go
@@ -1,18 +1,21 @@
 package shaper
 
-import "time"
+import (
+	"math"
+	"time"
+)
 
 // ConstantShaper is used to send txs with a constant frequency
 type ConstantShaper struct {
-	interval time.Duration
+	frequency float64
 }
 
-func NewConstantShaper(frequency float32) *ConstantShaper {
+func NewConstantShaper(frequency float64) *ConstantShaper {
 	return &ConstantShaper{
-		interval: time.Duration(float32(time.Second) / frequency),
+		frequency: frequency,
 	}
 }
 
-func (s *ConstantShaper) GetNextWaitTime() (time.Duration, bool) {
-	return s.interval, true
+func (s *ConstantShaper) GetNumMessagesInInterval(start time.Time, duration time.Duration) float64 {
+	return math.Max(duration.Seconds()*float64(s.frequency), 0)
 }

--- a/load/shaper/constant_test.go
+++ b/load/shaper/constant_test.go
@@ -1,22 +1,42 @@
 package shaper
 
 import (
+	"math"
 	"testing"
 	"time"
 )
 
 func TestConstantShaper(t *testing.T) {
-	// Create a ConstantShaper with a frequency of 100 Hz
-	shaper := NewConstantShaper(100)
+	tests := []struct {
+		frequency float64
+		duration  time.Duration
+		messages  float64
+	}{
+		// 100 Hz constant load
+		{100, 0 * time.Second, 0},
+		{100, 1 * time.Second, 100},
+		{100, 2 * time.Second, 200},
+		{100, 1 * time.Millisecond, 0.1},
+		{100, 10 * time.Millisecond, 1},
+		{100, 100 * time.Millisecond, 10},
+		{100, 250 * time.Millisecond, 25},
+		{100, 500 * time.Millisecond, 50},
 
-	expectedInterval := time.Second / 100
-	waitTime, send := shaper.GetNextWaitTime()
-
-	if !send {
-		t.Fatalf("Expected send to be true")
+		// Other frequencies.
+		{10, 500 * time.Millisecond, 5},
+		{20, 500 * time.Millisecond, 10},
+		{14, 500 * time.Millisecond, 7},
+		{7, 500 * time.Millisecond, 3.5},
+		{0, 500 * time.Millisecond, 0},
+		{-1, 500 * time.Millisecond, 0},
 	}
 
-	if waitTime != expectedInterval {
-		t.Fatalf("Expected %d, got %d", expectedInterval, waitTime)
+	for _, test := range tests {
+		shaper := NewConstantShaper(test.frequency)
+		got := shaper.GetNumMessagesInInterval(time.Now(), test.duration)
+		want := test.messages
+		if math.Abs(float64(got-want)) > 1e-6 {
+			t.Errorf("incorrect number of messages, wanted %f, got %f", want, got)
+		}
 	}
 }

--- a/load/shaper/shaper.go
+++ b/load/shaper/shaper.go
@@ -7,12 +7,11 @@ import (
 	"github.com/Fantom-foundation/Norma/driver/parser"
 )
 
-// Shaper defines delays between produced txs to ensure desired produced traffic profile.
+// Shaper defines the shape of traffic to be produced by an application.
 type Shaper interface {
-	// GetNextWaitTime provides the time to wait before the next tx should be sent
-	// If the returned bool is false, no transaction should be sent and shaper should be asked
-	// again after the duration returned by GetNextWaitTime.
-	GetNextWaitTime() (time.Duration, bool)
+	// GetNumMessagesInInterval provides the number of messages to be produced
+	// in the given time interval. The result is expected to be >= 0.
+	GetNumMessagesInInterval(start time.Time, duration time.Duration) float64
 }
 
 // ParseRate parses rate from the parser.
@@ -23,10 +22,10 @@ func ParseRate(rate *parser.Rate) (Shaper, error) {
 	}
 
 	if rate.Constant != nil {
-		return NewConstantShaper(*rate.Constant), nil
+		return NewConstantShaper(float64(*rate.Constant)), nil
 	}
 	if rate.Slope != nil {
-		return NewSlopeShaper(rate.Slope.Start, rate.Slope.Increment), nil
+		return NewSlopeShaper(float64(rate.Slope.Start), float64(rate.Slope.Increment)), nil
 	}
 
 	// TODO: add wave shaper

--- a/load/shaper/slope.go
+++ b/load/shaper/slope.go
@@ -8,52 +8,64 @@ import (
 // SlopeShaper is used to send txs with a linearly increasing frequency.
 // It is defined as follows:
 type SlopeShaper struct {
-	startFrequency     float32
-	incrementFrequency float32
+	startFrequency     float64
+	incrementFrequency float64
 	// startTimeStamp is the time when the wait time was first obtained.
 	startTimeStamp time.Time
 }
 
-func NewSlopeShaper(startFrequency, incrementFrequency float32) *SlopeShaper {
+func NewSlopeShaper(startFrequency, incrementFrequency float64) *SlopeShaper {
 	return &SlopeShaper{
 		startFrequency:     startFrequency,
 		incrementFrequency: incrementFrequency,
 	}
 }
 
-// GetNextWaitTime returns the next wait time based on the current timestamp
-// and start and increment frequency
-func (s *SlopeShaper) GetNextWaitTime() (time.Duration, bool) {
-	now := time.Now()
-	// if this is the first call, set the start time stamp
+// GetNumMessagesInInterval provides the number of messages to be produced
+// in the given time interval.
+func (s *SlopeShaper) GetNumMessagesInInterval(start time.Time, duration time.Duration) float64 {
+	// the shaper starts its slope the first time it is called.
 	if s.startTimeStamp.IsZero() {
-		s.startTimeStamp = now
-	}
-	return s.GetWaitTimeForTimeStamp(now)
-}
-
-// GetWaitTimeForTimeStamp returns the wait time for the given timestamp
-func (s *SlopeShaper) GetWaitTimeForTimeStamp(current time.Time) (time.Duration, bool) {
-	timeSinceStart := current.Sub(s.startTimeStamp).Seconds()
-
-	// if the time since start is 0 and the start frequency is 0, then
-	// signal to the consumer that he should ask later again
-	// this is special case for the first call to GetNextWaitTime
-	if timeSinceStart == 0 && s.startFrequency == 0 {
-		// calculate the duration from absolute value (might be negative) of the increment frequency
-		return time.Duration(float32(time.Second) / float32(math.Abs(float64(s.incrementFrequency)))), false
+		s.startTimeStamp = start
 	}
 
-	// calculate the current frequency as linear function t(n) = s + n * i,
-	// where `s` is the start frequency, `n` is the time since start and `i` is the increment frequency
-	currentFrequency := s.startFrequency + float32(timeSinceStart)*s.incrementFrequency
+	// The number of messages to be sent in the interval is equal to the area
+	// under the frequency-time curve given by
+	//
+	//   f(t) := startFrequency + increment * t = d + k * t
+	//
+	// The area is equal to the definit integral over the given time range [a,b]
+	// which can be computed as
+	//
+	//   m(a,b) := \int_{a}^{b} k * t + d
+	//           = (k*b^2/2 + d*b + c) - (k*a^2/2 + d*a + c)
+	//           = k*b^2/2 + d*b - k*a^2/2 - d*a
+	//           = k/2 * (b^2-a^2) + d * (b-a)
+	//           = incrment/2 * (b^2-a^2) + startFrequency * (b-a)
+	//
+	// assuming the frequency is always positive in the range [a,b]. Otherwise,
+	// the interval needs to be limited to the positive part.
 
-	// if the current frequency decreased to 0, it means, that the increment frequency is negative,
-	// and we reached from which we won't send anymore txs, so we return infinity as the wait time
-	if currentFrequency <= 0 {
-		return time.Duration(math.Inf(1)), false
+	// Relative begin and end time of interval [a,b].
+	a := start.Sub(s.startTimeStamp).Seconds()
+	b := a + duration.Seconds()
+
+	// Special case: if the slope is constant (there may be no zero point).
+	if s.incrementFrequency == 0 {
+		return (b - a) * s.startFrequency
 	}
 
-	// return the wait time for the current frequency
-	return time.Duration(float32(time.Second) / currentFrequency), true
+	// the zero point (time at which the frequency is zero)
+	z := -s.startFrequency / s.incrementFrequency
+
+	// Restrict range if the zero point is in the interval.
+	if s.incrementFrequency > 0 {
+		a = math.Max(z, a)
+		b = math.Max(z, b)
+	} else {
+		a = math.Min(z, a)
+		b = math.Min(z, b)
+	}
+
+	return (s.incrementFrequency/2)*(b*b-a*a) + s.startFrequency*(b-a)
 }


### PR DESCRIPTION
This PR restructures the architecture of the load shaper by replacing the delay-based approach with a throughput-based approach.

In particular, instead of letting the load shapes report waiting times to the next messages, shapers are now reporting the number of messages expected to be sent during a given time interval. This enables the controller to produce load more accurately and with higher rates.

Before (slope with 40 Tx/s^2):
![image](https://github.com/Fantom-foundation/Norma/assets/4097849/b5fb57b3-0d19-464a-93a8-870e41166542)

After (slope with 40 Tx/s^2):
![image](https://github.com/Fantom-foundation/Norma/assets/4097849/202f0f98-129a-41e9-be62-1d2765ceb4ca)
