### PR TITLE
Check bound port is freed while searching ports

### DIFF
--- a/driver/monitoring/node/cpu_profile_test.go
+++ b/driver/monitoring/node/cpu_profile_test.go
@@ -14,7 +14,9 @@ func TestCanCollectCpuProfileDateFromOperaNode(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create a docker client: %v", err)
 	}
-	defer docker.Close()
+	t.Cleanup(func() {
+		_ = docker.Close()
+	})
 	node, err := opera.StartOperaDockerNode(docker, nil, &opera.OperaNodeConfig{
 		Label:         "test",
 		NetworkConfig: &driver.NetworkConfig{NumberOfValidators: 1},
@@ -22,8 +24,9 @@ func TestCanCollectCpuProfileDateFromOperaNode(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create an Opera node on Docker: %v", err)
 	}
-	defer node.Cleanup()
-
+	t.Cleanup(func() {
+		_ = node.Cleanup()
+	})
 	data, err := GetPprofData(node, time.Second)
 	if err != nil {
 		t.Errorf("failed to collect pprof data from node: %v", err)

--- a/driver/network/service.go
+++ b/driver/network/service.go
@@ -64,6 +64,7 @@ func GetFreePorts(num int) ([]Port, error) {
 				log.Printf("failed to create a new listening port")
 				continue
 			}
+			// make sure to close the listener in case of an error
 			defer listener.Close()
 
 			port := listener.Addr().String()
@@ -79,6 +80,14 @@ func GetFreePorts(num int) ([]Port, error) {
 				log.Printf("invalid port format: %s, err: %v", port, err)
 				continue
 			}
+
+			// close the listener, if it fails, we will not be able to use the port,
+			// because it is bound
+			if err := listener.Close(); err != nil {
+				log.Printf("failed to close listener: %v", err)
+				continue
+			}
+
 			ports = append(ports, Port(res))
 			found = true
 		}

--- a/driver/node/opera_test.go
+++ b/driver/node/opera_test.go
@@ -24,7 +24,9 @@ func TestOperaNode_StartAndStop(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create a docker client: %v", err)
 	}
-	defer docker.Close()
+	t.Cleanup(func() {
+		_ = docker.Close()
+	})
 	node, err := StartOperaDockerNode(docker, nil, &OperaNodeConfig{
 		Label:         "test",
 		NetworkConfig: &driver.NetworkConfig{NumberOfValidators: 1},
@@ -32,6 +34,9 @@ func TestOperaNode_StartAndStop(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create an Opera node on Docker: %v", err)
 	}
+	t.Cleanup(func() {
+		_ = node.Cleanup()
+	})
 	if err = node.host.Stop(); err != nil {
 		t.Errorf("failed to stop Opera node: %v", err)
 	}
@@ -42,7 +47,9 @@ func TestOperaNode_RpcServiceIsReadyAfterStartup(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create a docker client: %v", err)
 	}
-	defer docker.Close()
+	t.Cleanup(func() {
+		_ = docker.Close()
+	})
 	node, err := StartOperaDockerNode(docker, nil, &OperaNodeConfig{
 		Label:         "test",
 		NetworkConfig: &driver.NetworkConfig{NumberOfValidators: 1},
@@ -50,6 +57,9 @@ func TestOperaNode_RpcServiceIsReadyAfterStartup(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create an Opera node on Docker: %v", err)
 	}
+	t.Cleanup(func() {
+		_ = node.Cleanup()
+	})
 	if id, err := node.GetNodeID(); err != nil || len(id) == 0 {
 		t.Errorf("failed to fetch NodeID from Opera node: '%v', err: %v", id, err)
 	}


### PR DESCRIPTION
Add check that bound port was freed while searching for available ports on host. This issue was making MacOS tests fail.