### PR TITLE
closes the RPC loop channel when network shutdown

### DIFF
--- a/driver/network/rpc/rpc_pool_test.go
+++ b/driver/network/rpc/rpc_pool_test.go
@@ -2,6 +2,8 @@ package rpc
 
 import (
 	"github.com/ethereum/go-ethereum/core/types"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -9,10 +11,9 @@ import (
 func TestRetryRpcReturnGracefully(t *testing.T) {
 	t.Parallel()
 
-	txs := make(chan *types.Transaction)
-
+	pool := NewRpcWorkerPool()
 	start := time.Now()
-	err := runRpcSenderLoop("wrong", 6, txs)
+	err := pool.runRpcSenderLoop("wrong", 6)
 
 	// we expect error, but should not panic
 	if err == nil {
@@ -21,5 +22,44 @@ func TestRetryRpcReturnGracefully(t *testing.T) {
 
 	if got, want := time.Now().Sub(start).Seconds(), float64(5); got < want {
 		t.Errorf("RPC should be attempted around 6s, was: %f < %f", got, want)
+	}
+}
+
+func TestClosePool(t *testing.T) {
+	t.Parallel()
+
+	pool := NewRpcWorkerPool()
+	counter := &atomic.Int32{}
+	wg := &sync.WaitGroup{}
+
+	go func() {
+		for range pool.txs {
+			counter.Add(1)
+			wg.Done()
+		}
+		wg.Done() // will get here when the channel is closed
+	}()
+
+	var tx types.Transaction
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		pool.SendTransaction(&tx)
+	}
+
+	wg.Wait()
+	wg.Add(1) // extra count to check the go routine ended
+
+	if got, want := counter.Load(), int32(10); got != want {
+		t.Errorf("not all data read from the channel: %d != %d", got, want)
+	}
+
+	if err := pool.Close(); err != nil {
+		t.Fatalf("error: %s", err)
+	}
+
+	wg.Wait()
+
+	if got, want := counter.Load(), int32(10); got > want {
+		t.Errorf("not all data read from the channel: %d != %d", got, want)
 	}
 }

--- a/load/controller/controller_test.go
+++ b/load/controller/controller_test.go
@@ -47,7 +47,8 @@ func TestLoadGeneration_CanRealizeConstantTrafficShape(t *testing.T) {
 			user.EXPECT().GenerateTx().AnyTimes().Return(&transaction, nil)
 
 			shaper := shaper.NewConstantShaper(float64(rate))
-			controller, err := NewAppController(application, shaper, 100, net)
+			wg := &sync.WaitGroup{}
+			controller, err := NewAppController(application, shaper, 100, net, wg)
 			if err != nil {
 				t.Fatalf("failed to create app controller: %v", err)
 			}

--- a/load/controller/mocked_test.go
+++ b/load/controller/mocked_test.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
@@ -39,7 +40,8 @@ func TestMockedTrafficGenerating(t *testing.T) {
 	// use constant shaper
 	constantShaper := shaper.NewConstantShaper(100) // 100 txs/sec
 
-	appController, err := NewAppController(mockedApp, constantShaper, numUsers, mockedNetwork)
+	wg := &sync.WaitGroup{}
+	appController, err := NewAppController(mockedApp, constantShaper, numUsers, mockedNetwork, wg)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/load/controller/rpc_test.go
+++ b/load/controller/rpc_test.go
@@ -2,10 +2,10 @@ package controller_test
 
 import (
 	"context"
+	"github.com/Fantom-foundation/Norma/driver/network"
+	"sync"
 	"testing"
 	"time"
-
-	"github.com/Fantom-foundation/Norma/driver/network"
 
 	"github.com/Fantom-foundation/Norma/driver"
 	"github.com/Fantom-foundation/Norma/driver/network/local"
@@ -52,7 +52,8 @@ func TestTrafficGenerating(t *testing.T) {
 	constantShaper := shaper.NewConstantShaper(30.0) // 30 txs/sec
 
 	numGenerators := 5 // 5 parallel workers
-	app, err := controller.NewAppController(application, constantShaper, numGenerators, net)
+	wg := &sync.WaitGroup{}
+	app, err := controller.NewAppController(application, constantShaper, numGenerators, net, wg)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This PR removes flooding of the log with RPC I/O errors when there is many unfinished requests when the network shutdowns. 

It waits for all go routines of the AppController to finish before progressing with shutdown. 
In addition, it closes also the RPC worker pool channel, which was not happening (not causing issues at the moment, but I think it is better to clean-all resources before shutdown)