### PR TITLE
Fix usage of priority gasPrice in apps

### DIFF
--- a/load/app/account.go
+++ b/load/app/account.go
@@ -60,10 +60,10 @@ func GenerateAndFundAccount(sourceAccount *Account, rpcClient RpcClient, regular
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate account; %v", err)
 	}
-	// transfers (tokens) FTM to the new account - finances to cover transaction fees
-	workerBudget := big.NewInt(0).Mul(big.NewInt(endowment), big.NewInt(1_000_000_000_000_000_000))
-	if err := transferValue(rpcClient, sourceAccount, account.address, workerBudget, priorityGasPrice); err != nil {
-		return nil, fmt.Errorf("failed to fund account: %v", err)
+	// transfers (tokens) FTM to the new account
+	value := big.NewInt(0).Mul(big.NewInt(endowment), big.NewInt(1_000_000_000_000_000_000)) // FTM to wei
+	if err := transferValue(rpcClient, sourceAccount, account.address, value, priorityGasPrice); err != nil {
+		return nil, fmt.Errorf("failed to transfer (value: %s, gasPrice: %s): %v", value, priorityGasPrice, err)
 	}
 	return account, nil
 }

--- a/load/app/counter_app.go
+++ b/load/app/counter_app.go
@@ -84,7 +84,7 @@ func (f *CounterApplication) CreateUser(rpcClient RpcClient) (User, error) {
 	startingAccount := f.startingAccounts[id%int64(len(f.startingAccounts))]
 	workerAccount, err := GenerateAndFundAccount(startingAccount, rpcClient, regularGasPrice, int(id), 1000)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to fund worker account %d; %v", id, err)
 	}
 
 	gen := &CounterUser{

--- a/load/app/erc20_app.go
+++ b/load/app/erc20_app.go
@@ -98,9 +98,9 @@ func (f *ERC20Application) CreateUser(rpcClient RpcClient) (User, error) {
 	// generate a new account for each worker - avoid account nonces related bottlenecks
 	id := atomic.AddInt64(&f.numAccounts, 1)
 	startingAccount := f.startingAccounts[id%int64(len(f.startingAccounts))]
-	workerAccount, err := GenerateAndFundAccount(startingAccount, rpcClient, getPriorityGasPrice(regularGasPrice), int(id), 1000)
+	workerAccount, err := GenerateAndFundAccount(startingAccount, rpcClient, regularGasPrice, int(id), 1000)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to fund worker account %d; %v", id, err)
 	}
 
 	// mint ERC-20 tokens for the worker account - tokens to be transferred in the transactions

--- a/load/app/helpers.go
+++ b/load/app/helpers.go
@@ -82,7 +82,7 @@ func generateStartingAccounts(rpcClient RpcClient, primaryAccount *Account, numA
 	for i := 0; i < len(startingAccounts); i++ {
 		startingAccounts[i], err = GenerateAndFundAccount(primaryAccount, rpcClient, regularGasPrice, i, 1_000_000)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("failed to fund starting account %d; %v", i, err)
 		}
 	}
 	return startingAccounts, nil

--- a/load/app/store_app.go
+++ b/load/app/store_app.go
@@ -83,7 +83,7 @@ func (f *StoreApplication) CreateUser(rpcClient RpcClient) (User, error) {
 	startingAccount := f.startingAccounts[id%int64(len(f.startingAccounts))]
 	workerAccount, err := GenerateAndFundAccount(startingAccount, rpcClient, regularGasPrice, int(id), 1000)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to fund worker account %d; %v", id, err)
 	}
 
 	gen := &StoreUser{

--- a/load/app/uniswap_app.go
+++ b/load/app/uniswap_app.go
@@ -149,9 +149,9 @@ func (f *UniswapApplication) CreateUser(rpcClient RpcClient) (User, error) {
 	// generate a new account for each worker - avoid account nonces related bottlenecks
 	id := atomic.AddInt64(&f.numAccounts, 1)
 	startingAccount := f.startingAccounts[id%int64(len(f.startingAccounts))]
-	workerAccount, err := GenerateAndFundAccount(startingAccount, rpcClient, getPriorityGasPrice(regularGasPrice), int(id), 1000)
+	workerAccount, err := GenerateAndFundAccount(startingAccount, rpcClient, regularGasPrice, int(id), 1000)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to fund worker account %d; %v", id, err)
 	}
 
 	// mint ERC-20 tokens for the worker account - tokens to be transferred in the transactions


### PR DESCRIPTION
This should fix OSX test failures:
```
 --- FAIL: TestGenerators (215.58s)
    --- FAIL: TestGenerators/Store (5.56s)
        app_test.go:106: unexpected amount of txs in chain (1)
    --- FAIL: TestGenerators/Uniswap (16.05s)
        app_test.go:78: failed to fund account: insufficient funds for gas * price + value
```
It seems, because of incorrect (doubled) usage of `getPriorityGasPrice`, too high gasPrice is set.
The unexpected amount of tx in chain may be resolved by using `network.Retry`.
This also extends error reporting, so we should see more details if the failure repeats.