### PR TITLE
starts generation of events only when the application has started as …

### DIFF
--- a/driver/network/local/local.go
+++ b/driver/network/local/local.go
@@ -209,6 +209,7 @@ type localApplication struct {
 func (a *localApplication) Start() error {
 	ctx, cancel := context.WithCancel(context.Background())
 	a.cancel = cancel
+
 	a.done.Add(1)
 	go func() {
 		defer a.done.Done()
@@ -277,8 +278,7 @@ func (n *LocalNetwork) CreateApplication(config *driver.ApplicationConfig) (driv
 		return nil, fmt.Errorf("failed to parse shaper; %v", err)
 	}
 
-	done := &sync.WaitGroup{}
-	appController, err := controller.NewAppController(application, sh, config.Users, n, done)
+	appController, err := controller.NewAppController(application, sh, config.Users, n)
 	if err != nil {
 		return nil, err
 	}
@@ -287,7 +287,7 @@ func (n *LocalNetwork) CreateApplication(config *driver.ApplicationConfig) (driv
 		name:       config.Name,
 		controller: appController,
 		config:     config,
-		done:       done,
+		done:       &sync.WaitGroup{},
 	}
 
 	n.appsMutex.Lock()

--- a/load/controller/controller_test.go
+++ b/load/controller/controller_test.go
@@ -47,8 +47,7 @@ func TestLoadGeneration_CanRealizeConstantTrafficShape(t *testing.T) {
 			user.EXPECT().GenerateTx().AnyTimes().Return(&transaction, nil)
 
 			shaper := shaper.NewConstantShaper(float64(rate))
-			wg := &sync.WaitGroup{}
-			controller, err := NewAppController(application, shaper, 100, net, wg)
+			controller, err := NewAppController(application, shaper, 100, net)
 			if err != nil {
 				t.Fatalf("failed to create app controller: %v", err)
 			}

--- a/load/controller/mocked_test.go
+++ b/load/controller/mocked_test.go
@@ -2,7 +2,6 @@ package controller
 
 import (
 	"context"
-	"sync"
 	"testing"
 	"time"
 
@@ -40,8 +39,7 @@ func TestMockedTrafficGenerating(t *testing.T) {
 	// use constant shaper
 	constantShaper := shaper.NewConstantShaper(100) // 100 txs/sec
 
-	wg := &sync.WaitGroup{}
-	appController, err := NewAppController(mockedApp, constantShaper, numUsers, mockedNetwork, wg)
+	appController, err := NewAppController(mockedApp, constantShaper, numUsers, mockedNetwork)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/load/controller/rpc_test.go
+++ b/load/controller/rpc_test.go
@@ -3,7 +3,6 @@ package controller_test
 import (
 	"context"
 	"github.com/Fantom-foundation/Norma/driver/network"
-	"sync"
 	"testing"
 	"time"
 
@@ -52,8 +51,7 @@ func TestTrafficGenerating(t *testing.T) {
 	constantShaper := shaper.NewConstantShaper(30.0) // 30 txs/sec
 
 	numGenerators := 5 // 5 parallel workers
-	wg := &sync.WaitGroup{}
-	app, err := controller.NewAppController(application, constantShaper, numGenerators, net, wg)
+	app, err := controller.NewAppController(application, constantShaper, numGenerators, net)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This PR starts generator of events only when the application is started as well - It used to be started as soon as application was created. 

It caused freeze when application Start() was not called yet, and ctrl+c was received, it froze in Stop() of application. 