### PR TITLE
Fix app deploy failure when non-validator rpc is used

### DIFF
--- a/driver/network/local/local.go
+++ b/driver/network/local/local.go
@@ -182,7 +182,11 @@ func (n *LocalNetwork) DialRandomRpc() (rpc2.RpcClient, error) {
 	return nodes[rand.Intn(len(nodes))].DialRpc()
 }
 
-// reasureAccountPrivateKey is an account with tokens that can be used to
+func (n *LocalNetwork) dialRandomValidatorRpc() (rpc2.RpcClient, error) {
+	return n.validators[rand.Intn(len(n.validators))].DialRpc()
+}
+
+// treasureAccountPrivateKey is an account with tokens that can be used to
 // initiate test applications and accounts.
 const treasureAccountPrivateKey = "163f5f0f9a621d72fedd85ffca3d08d131ab4e812181e0d30ffd1c885d20aac7" // Fakenet validator 1
 
@@ -239,7 +243,7 @@ func (a *localApplication) GetReceivedTransactions() (uint64, error) {
 }
 
 func (n *LocalNetwork) CreateApplication(config *driver.ApplicationConfig) (driver.Application, error) {
-	rpcClient, err := n.DialRandomRpc()
+	rpcClient, err := n.dialRandomValidatorRpc()
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to RPC to initialize the application; %v", err)
 	}


### PR DESCRIPTION
This fixes flaky test failure introduced in #155 - deploying the app fails, when non-validator RPC is used for the deployment.
This is flaky, because the test succeed when DialRandomRpc() have chosen a validator RPC.

```
--- FAIL: TestLocalNetwork_CanPerformNetworkShutdown (75.89s)
    local_test.go:132: failed to create app: failed to initialize on-chain app; failed to wait until the Counter contract is deployed; nonce not achieved before timeout (awaited 2, current 0)
    local_test.go:132: failed to create app: failed to initialize on-chain app; failed to wait until the Counter contract is deployed; nonce not achieved before timeout (awaited 4, current 0)
```
The deploy fails on timeout, because the non-validator rpc starts later and is not synced (with deployed contract) in time.