### PR TITLE
Add --vm-impl flag to Norma runner

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,6 +65,7 @@ COPY --from=carmen-build /client/carmen/go/lib/libcarmen.so .
 ENV VALIDATOR_NUMBER=1
 ENV VALIDATORS_COUNT=1
 ENV STATE_DB_IMPL="geth"
+ENV VM_IMPL="geth"
 ENV LD_LIBRARY_PATH=./
 
 EXPOSE 6060

--- a/driver/network.go
+++ b/driver/network.go
@@ -55,6 +55,8 @@ type NetworkConfig struct {
 	NumberOfValidators int
 	// The name of the StateDB implementation to be used by network nodes.
 	StateDbImplementation string
+	// The name of the EVM implementation to be used by network nodes.
+	VmImplementation string
 }
 
 // NetworkListener can be registered to networks to get callbacks whenever there

--- a/driver/network/local/local.go
+++ b/driver/network/local/local.go
@@ -99,9 +99,10 @@ func NewLocalNetwork(config *driver.NetworkConfig) (*LocalNetwork, error) {
 			defer wg.Done()
 			validatorId := i + 1
 			nodeConfig := node.OperaNodeConfig{
-				ValidatorId:   &validatorId,
-				NetworkConfig: config,
-				Label:         fmt.Sprintf("_validator-%d", validatorId),
+				ValidatorId:      &validatorId,
+				NetworkConfig:    config,
+				Label:            fmt.Sprintf("_validator-%d", validatorId),
+				VmImplementation: config.VmImplementation,
 			}
 			net.validators[i], errs[i] = net.createNode(&nodeConfig)
 		}()

--- a/driver/node/opera.go
+++ b/driver/node/opera.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	rpc2 "github.com/Fantom-foundation/Norma/driver/rpc"
 	"io"
 	"regexp"
 	"time"
+
+	rpc2 "github.com/Fantom-foundation/Norma/driver/rpc"
 
 	"github.com/Fantom-foundation/Norma/driver"
 	"github.com/Fantom-foundation/Norma/driver/docker"
@@ -63,6 +64,8 @@ type OperaNodeConfig struct {
 	ValidatorId *int
 	// The configuration of the network the configured node should be part of.
 	NetworkConfig *driver.NetworkConfig
+	// The EVM implementation to be used on this node.
+	VmImplementation string
 }
 
 // labelPattern restricts labels for nodes to non-empty alpha-numerical strings
@@ -99,6 +102,7 @@ func StartOperaDockerNode(client *docker.Client, dn *docker.Network, config *Ope
 				"VALIDATOR_NUMBER": validatorId,
 				"VALIDATORS_COUNT": fmt.Sprintf("%d", config.NetworkConfig.NumberOfValidators),
 				"STATE_DB_IMPL":    config.NetworkConfig.StateDbImplementation,
+				"VM_IMPL":          config.VmImplementation,
 			},
 			Network: dn,
 		})

--- a/scripts/run_opera.sh
+++ b/scripts/run_opera.sh
@@ -6,7 +6,9 @@ external_ip=${array[0]}
 echo "Opera is going to export its services on ${external_ip}"
 
 # Starting opera as part of a fake net with RPC service.
-./opera --fakenet ${VALIDATOR_NUMBER}/${VALIDATORS_COUNT} --statedb.impl=${STATE_DB_IMPL} \
+./opera --fakenet ${VALIDATOR_NUMBER}/${VALIDATORS_COUNT} \
+    --statedb.impl=${STATE_DB_IMPL} \
+    --vm.impl=${VM_IMPL} \
     --fakenetgaspower 1000 \
     --http --http.addr 0.0.0.0 --http.port 18545 --http.api admin,eth,ftm \
     --ws --ws.addr 0.0.0.0 --ws.port 18546 --ws.api admin,eth,ftm \


### PR DESCRIPTION
With this flag users can select in the command line which virtual machine implementation should be used for the evaluation.