### PR TITLE
creates listener for removed nodes

### DIFF
--- a/driver/monitoring/app/app_source.go
+++ b/driver/monitoring/app/app_source.go
@@ -57,6 +57,10 @@ func (s *periodicAppDataSource[T]) AfterNodeCreation(driver.Node) {
 	// ignored
 }
 
+func (s *periodicAppDataSource[T]) AfterNodeRemoval(driver.Node) {
+	// ignored
+}
+
 func (s *periodicAppDataSource[T]) AfterApplicationCreation(app driver.Application) {
 	label := app.Config().Name
 	sensor, err := s.factory.CreateSensor(app)

--- a/driver/monitoring/node/node_source.go
+++ b/driver/monitoring/node/node_source.go
@@ -63,6 +63,10 @@ func (s *periodicNodeDataSource[T]) AfterNodeCreation(node driver.Node) {
 	s.AddSubject(mon.Node(label), sensor)
 }
 
+func (s *periodicNodeDataSource[T]) AfterNodeRemoval(driver.Node) {
+
+}
+
 func (s *periodicNodeDataSource[T]) AfterApplicationCreation(driver.Application) {
 	// ignored
 }

--- a/driver/monitoring/node_log_provider.go
+++ b/driver/monitoring/node_log_provider.go
@@ -118,6 +118,14 @@ func (n *NodeLogDispatcher) AfterNodeCreation(node driver.Node) {
 	}
 }
 
+func (n *NodeLogDispatcher) AfterNodeRemoval(node driver.Node) {
+	n.nodesLock.Lock()
+	defer n.nodesLock.Unlock()
+
+	nodeId := node.GetLabel()
+	delete(n.nodes, Node(nodeId))
+}
+
 func (n *NodeLogDispatcher) AfterApplicationCreation(driver.Application) {
 	// ignored
 }

--- a/driver/monitoring/prometheus/prometheus.go
+++ b/driver/monitoring/prometheus/prometheus.go
@@ -123,6 +123,10 @@ func (p *Prometheus) AfterNodeCreation(node driver.Node) {
 	}
 }
 
+func (p *Prometheus) AfterNodeRemoval(driver.Node) {
+	// ignored
+}
+
 func (p *Prometheus) AfterApplicationCreation(driver.Application) {
 	// ignored
 }

--- a/driver/monitoring/user/user_source.go
+++ b/driver/monitoring/user/user_source.go
@@ -57,6 +57,10 @@ func (s *periodicUserDataSource[T]) AfterNodeCreation(driver.Node) {
 	// ignored
 }
 
+func (s *periodicUserDataSource[T]) AfterNodeRemoval(driver.Node) {
+	// ignored
+}
+
 func (s *periodicUserDataSource[T]) AfterApplicationCreation(app driver.Application) {
 	label := mon.App(app.Config().Name)
 	for i := 0; i < app.Config().Users; i++ {

--- a/driver/network.go
+++ b/driver/network.go
@@ -64,6 +64,8 @@ type NetworkConfig struct {
 type NetworkListener interface {
 	// AfterNodeCreation is called whenever a new node has joined the network.
 	AfterNodeCreation(Node)
+	// AfterNodeRemoval is called whenever a node is removed from the network.
+	AfterNodeRemoval(Node)
 	// AfterApplicationCreation is called after a new application has started.
 	AfterApplicationCreation(Application)
 }

--- a/driver/network/local/local.go
+++ b/driver/network/local/local.go
@@ -177,6 +177,12 @@ func (n *LocalNetwork) RemoveNode(node driver.Node) error {
 	}
 	n.nodesMutex.Unlock()
 
+	n.listenerMutex.Lock()
+	for listener := range n.listeners {
+		listener.AfterNodeRemoval(node)
+	}
+	n.listenerMutex.Unlock()
+
 	return nil
 }
 

--- a/driver/network/local/local_test.go
+++ b/driver/network/local/local_test.go
@@ -237,6 +237,12 @@ func TestLocalNetwork_CanRemoveNode(t *testing.T) {
 		t.Run(fmt.Sprintf("num_nodes=%d", N), func(t *testing.T) {
 			t.Parallel()
 			net, err := NewLocalNetwork(&config)
+			ctrl := gomock.NewController(t)
+			listener := driver.NewMockNetworkListener(ctrl)
+			listener.EXPECT().AfterNodeCreation(gomock.Any()).Times(N)
+			listener.EXPECT().AfterNodeRemoval(gomock.Any()).Times(N)
+			net.RegisterListener(listener)
+
 			if err != nil {
 				t.Fatalf("failed to create new local network: %v", err)
 			}

--- a/driver/network_mock.go
+++ b/driver/network_mock.go
@@ -218,3 +218,15 @@ func (mr *MockNetworkListenerMockRecorder) AfterNodeCreation(arg0 interface{}) *
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AfterNodeCreation", reflect.TypeOf((*MockNetworkListener)(nil).AfterNodeCreation), arg0)
 }
+
+// AfterNodeRemoval mocks base method.
+func (m *MockNetworkListener) AfterNodeRemoval(arg0 Node) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "AfterNodeRemoval", arg0)
+}
+
+// AfterNodeRemoval indicates an expected call of AfterNodeRemoval.
+func (mr *MockNetworkListenerMockRecorder) AfterNodeRemoval(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AfterNodeRemoval", reflect.TypeOf((*MockNetworkListener)(nil).AfterNodeRemoval), arg0)
+}


### PR DESCRIPTION
this PR adds a listener that distributes removal of a node from the network. This listener was used at some places to remove `I/O` and similar errors when a node was removed from the network and various components still tried to access the node. 

In particular, this was used in the `rpc_pool` and `prom_log_provider`. Both these components did not have information about a removed node and still tired to access already removed nodes. 

There are still some metric sources in the code, which would need to use this listener as well - it is not done in this PR at the moment.

Example of log messages before this PR is applied - they should disappear after this PR is merged  

```
2023/07/31 22:49:00 failed to send tx; dial tcp [::1]:60955: i/o timeout
2023/07/31 22:49:00 failed to send tx; dial tcp [::1]:60955: i/o timeout
2023/07/31 22:49:00 failed to send tx; dial tcp [::1]:60955: i/o timeout
2023/07/31 22:49:00 failed to send tx; dial tcp [::1]:60955: i/o timeout
2023/07/31 22:49:00 failed to send tx; dial tcp [::1]:60955: i/o timeout
2023/07/31 22:49:00 failed to send tx; dial tcp [::1]:60955: i/o timeout
2023/07/31 22:49:00 failed to send tx; dial tcp [::1]:60955: i/o timeout
2023/07/31 22:49:00 failed to send tx; dial tcp [::1]:60955: i/o timeout
2023/07/31 22:49:00 failed to send tx; dial tcp [::1]:61115: i/o timeout
2023/07/31 22:49:00 failed to send tx; dial tcp [::1]:61115: i/o timeout
2023/07/31 22:49:00 failed to send tx; dial tcp [::1]:61141: i/o timeout
2023/07/31 22:49:00 failed to send tx; dial tcp [::1]:61141: i/o timeout

Execution completed successfully!
Checking network consistency ...
2023/07/31 09:39:44 monitoring: failed to parse log: Get "http://localhost:58862/debug/metrics/prometheus": dial tcp [::1]:58862: connect: connection refused
2023/07/31 09:39:44 monitoring: failed to parse log: Get "http://localhost:58513/debug/metrics/prometheus": dial tcp [::1]:58513: connect: connection refused
2023/07/31 09:39:44 monitoring: failed to parse log: Get "http://localhost:58519/debug/metrics/prometheus": dial tcp [::1]:58519: connect: connection refused
Network checks succeed.
```