### PR TITLE
Kjezek/avoid connection errors when shutdown

### DIFF
--- a/driver/monitoring/node/node_source.go
+++ b/driver/monitoring/node/node_source.go
@@ -63,8 +63,9 @@ func (s *periodicNodeDataSource[T]) AfterNodeCreation(node driver.Node) {
 	s.AddSubject(mon.Node(label), sensor)
 }
 
-func (s *periodicNodeDataSource[T]) AfterNodeRemoval(driver.Node) {
-
+func (s *periodicNodeDataSource[T]) AfterNodeRemoval(node driver.Node) {
+	label := node.GetLabel()
+	s.RemoveSubject(mon.Node(label))
 }
 
 func (s *periodicNodeDataSource[T]) AfterApplicationCreation(driver.Application) {


### PR DESCRIPTION
This PR properly stops querying of nodes that they were already closed. 

It removes `connection error` type messages when nodes are closed