### PR TITLE
Update Norma to Sonic 57863ea

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ BUILD_DIR := $(CURDIR)/build
 
 .PHONY: all test clean
 
-all: build-opera-docker-image norma
+all: build-sonic-docker-image norma
 
 pull-hello-world-image:
 	DOCKER_BUILDKIT=1 docker image pull hello-world
@@ -29,8 +29,8 @@ pull-alpine-image:
 pull-prometheus-image:
 	DOCKER_BUILDKIT=1 docker image pull prom/prometheus:v2.44.0
 
-build-opera-docker-image:
-	DOCKER_BUILDKIT=1 docker build . -t opera
+build-sonic-docker-image:
+	DOCKER_BUILDKIT=1 docker build . -t sonic
 
 generate-abi: load/contracts/abi/Counter.abi load/contracts/abi/ERC20.abi load/contracts/abi/Store.abi load/contracts/abi/UniswapV2Pair.abi load/contracts/abi/UniswapRouter.abi # requires installed solc and Ethereum abigen - check README.md
 
@@ -57,10 +57,10 @@ load/contracts/abi/UniswapRouter.abi: load/contracts/UniswapRouter.sol
 generate-mocks: # requires installed mockgen
 	go generate ./...
 
-norma: pull-prometheus-image build-opera-docker-image
+norma: pull-prometheus-image build-sonic-docker-image
 	go build -o $(BUILD_DIR)/norma ./driver/norma
 
-test: pull-hello-world-image pull-alpine-image pull-prometheus-image build-opera-docker-image
+test: pull-hello-world-image pull-alpine-image pull-prometheus-image build-sonic-docker-image
 	go test ./... -v
 
 clean:

--- a/driver/node/opera.go
+++ b/driver/node/opera.go
@@ -64,7 +64,7 @@ func init() {
 	}
 }
 
-const operaDockerImageName = "opera"
+const operaDockerImageName = "sonic"
 
 // OperaNode implements the driver's Node interface by running a go-opera
 // client on a generic host.

--- a/driver/node/opera_test.go
+++ b/driver/node/opera_test.go
@@ -125,7 +125,7 @@ func TestOperaNode_StreamLog(t *testing.T) {
 		scanner := bufio.NewScanner(reader)
 		for scanner.Scan() {
 			line := scanner.Text()
-			if strings.Contains(line, "Start/Switch to fullsync mode...") {
+			if strings.Contains(line, "WebSocket enabled") {
 				done <- true
 			}
 		}

--- a/driver/node/opera_test.go
+++ b/driver/node/opera_test.go
@@ -125,7 +125,7 @@ func TestOperaNode_StreamLog(t *testing.T) {
 		scanner := bufio.NewScanner(reader)
 		for scanner.Scan() {
 			line := scanner.Text()
-			if strings.Contains(line, "WebSocket enabled") {
+			if strings.Contains(line, "IPC endpoint opened") {
 				done <- true
 			}
 		}

--- a/scripts/run_sonic.sh
+++ b/scripts/run_sonic.sh
@@ -7,7 +7,7 @@ echo "Sonic is going to export its services on ${external_ip}"
 
 # Initialize datadir
 mkdir /datadir
-./sonictool --datadir=/datadir genesis fake ${VALIDATOR_NUMBER}
+./sonictool --datadir=/datadir genesis fake ${VALIDATORS_COUNT}
 
 # Start sonic as part of a fake net with RPC service.
 ./sonicd --fakenet ${VALIDATOR_NUMBER}/${VALIDATORS_COUNT} \

--- a/scripts/run_sonic.sh
+++ b/scripts/run_sonic.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Get the local node's IP.
+list=`hostname -I`
+array=($list)
+external_ip=${array[0]}
+echo "Sonic is going to export its services on ${external_ip}"
+
+# Initialize datadir
+mkdir /datadir
+./sonictool --datadir=/datadir genesis fake ${VALIDATOR_NUMBER}
+
+# Start sonic as part of a fake net with RPC service.
+./sonicd --fakenet ${VALIDATOR_NUMBER}/${VALIDATORS_COUNT} \
+    --datadir=/datadir \
+    --http --http.addr 0.0.0.0 --http.port 18545 --http.api admin,eth,ftm \
+    --ws --ws.addr 0.0.0.0 --ws.port 18546 --ws.api admin,eth,ftm \
+    --pprof --pprof.addr 0.0.0.0 \
+    --nat=extip:${external_ip} \
+    --metrics \
+    --metrics.expensive


### PR DESCRIPTION
> Note: This replaces the old build process:
> - previously was build go-opera-norma by 1. cloning carmen, tosca 2. build carmen locally (See [update-to-opera-norma-aa88d69](https://github.com/Fantom-foundation/Norma/tree/rapol/update-sonic/update-to-opera-norma-aa88d69)
> - current build is simply cloning carmen via go.mod
> 
> In future update, both should be available as an option. 
> Afterwards, compatibility of both (or more) client types simultaneously in the same scenarios.

No longer applicable. Will only support client that uses go.mod instead of submodules. 
