### PR TITLE
YML Update: Cheat

### DIFF
--- a/driver/executor/executor.go
+++ b/driver/executor/executor.go
@@ -53,7 +53,7 @@ func Run(clock Clock, network driver.Network, scenario *parser.Scenario) error {
 		}
 	}
 	for _, cheat := range scenario.Cheats {
-		scheduleCheatEvents(*cheat, queue, network, endTime)
+		scheduleCheatEvents(&cheat, queue, network, endTime)
 	}
 
 	// Register a handler for Ctrl+C events.

--- a/driver/executor/executor.go
+++ b/driver/executor/executor.go
@@ -52,6 +52,9 @@ func Run(clock Clock, network driver.Network, scenario *parser.Scenario) error {
 			return err
 		}
 	}
+	for _, cheat := range scenario.Cheats {
+		scheduleCheatEvents(*cheat, queue, network, endTime)
+	}
 
 	// Register a handler for Ctrl+C events.
 	abort := make(chan os.Signal, 1)
@@ -245,3 +248,18 @@ func scheduleApplicationEvents(source *parser.Application, queue *eventQueue, ne
 	}
 	return nil
 }
+
+// scheduleCheatEvents schedules a number of events covering the life-cycle of a class of
+// cheats during the scenario execution. Currently, a cheat is defined a simultaneous start 
+// of multiple validator nodes with the same key. 
+func scheduleCheatEvents(cheat *parser.Cheat, queue *eventQueue, net driver.Network, end Time) {
+	startTime := Time(0)
+	if cheat.Start != nil {
+		startTime = Seconds(*cheat.Start)
+	}
+	
+	queue.add(toSingleEvent(startTime, fmt.Sprintf("Attempting Cheat %s - currently unsupported cheat, nothing happens", cheat.Name), func() error {
+		return nil
+	}))
+}
+

--- a/driver/executor/executor.go
+++ b/driver/executor/executor.go
@@ -250,16 +250,15 @@ func scheduleApplicationEvents(source *parser.Application, queue *eventQueue, ne
 }
 
 // scheduleCheatEvents schedules a number of events covering the life-cycle of a class of
-// cheats during the scenario execution. Currently, a cheat is defined a simultaneous start 
-// of multiple validator nodes with the same key. 
+// cheats during the scenario execution. Currently, a cheat is defined a simultaneous start
+// of multiple validator nodes with the same key.
 func scheduleCheatEvents(cheat *parser.Cheat, queue *eventQueue, net driver.Network, end Time) {
 	startTime := Time(0)
 	if cheat.Start != nil {
 		startTime = Seconds(*cheat.Start)
 	}
-	
+
 	queue.add(toSingleEvent(startTime, fmt.Sprintf("Attempting Cheat %s - currently unsupported cheat, nothing happens", cheat.Name), func() error {
 		return nil
 	}))
 }
-

--- a/driver/parser/check.go
+++ b/driver/parser/check.go
@@ -63,6 +63,18 @@ func (s *Scenario) Check() error {
 			names[application.Name] = true
 		}
 	}
+	names = map[string]bool{}
+	for _, cheat := range s.Cheats {
+		if err := cheat.Check(s); err != nil {
+			errs = append(errs, err)
+		}
+		if _, exists := names[cheat.Name]; exists {
+			errs = append(errs, fmt.Errorf("cheat names must be unique, %s encountered multiple times", cheat.Name))
+		} else {
+			names[cheat.Name] = true
+		}
+	}
+
 	return errors.Join(errs...)
 }
 
@@ -115,6 +127,22 @@ func (a *Application) Check(scenario *Scenario) error {
 
 	return errors.Join(errs...)
 }
+
+// Check tests semantic constraints on the cheat configuration of a scenario.
+func (c *Cheat) Check(scenario *Scenario) error {
+	errs := []error{}
+
+	if !namePattern.Match([]byte(c.Name)) {
+		errs = append(errs, fmt.Errorf("cheat name must match %v, got %v", namePatternStr, c.Name))
+	}
+
+	if err := checkTimeInterval(c.Start, nil, scenario.Duration); err != nil {
+		errs = append(errs, err)
+	}
+
+	return errors.Join(errs...)
+}
+
 
 // Check tests semantic constraints on the traffic shape configuration of a source.
 func (r *Rate) Check(scenario *Scenario) error {

--- a/driver/parser/check.go
+++ b/driver/parser/check.go
@@ -143,7 +143,6 @@ func (c *Cheat) Check(scenario *Scenario) error {
 	return errors.Join(errs...)
 }
 
-
 // Check tests semantic constraints on the traffic shape configuration of a source.
 func (r *Rate) Check(scenario *Scenario) error {
 	count := 0

--- a/driver/parser/check_test.go
+++ b/driver/parser/check_test.go
@@ -17,8 +17,8 @@
 package parser
 
 import (
-	"strings"
 	"fmt"
+	"strings"
 	"testing"
 )
 
@@ -446,11 +446,11 @@ func TestScenario_ApplicationIssuesAreDetected(t *testing.T) {
 func TestScenario_CheatIssuesAreDetected(t *testing.T) {
 	start := new(float32)
 	*start = 70
-	
+
 	scenario := Scenario{
-		Name:         "Test",
-		Duration:     60,
-		Cheats: []Cheat {
+		Name:     "Test",
+		Duration: 60,
+		Cheats: []Cheat{
 			{Name: "Test", Start: start},
 		},
 	}
@@ -459,4 +459,3 @@ func TestScenario_CheatIssuesAreDetected(t *testing.T) {
 		t.Errorf("cheat issue was not detected")
 	}
 }
-

--- a/driver/parser/check_test.go
+++ b/driver/parser/check_test.go
@@ -18,6 +18,7 @@ package parser
 
 import (
 	"strings"
+	"fmt"
 	"testing"
 )
 
@@ -441,3 +442,21 @@ func TestScenario_ApplicationIssuesAreDetected(t *testing.T) {
 		t.Errorf("application issue was not detected")
 	}
 }
+
+func TestScenario_CheatIssuesAreDetected(t *testing.T) {
+	start := new(float32)
+	*start = 70
+	
+	scenario := Scenario{
+		Name:         "Test",
+		Duration:     60,
+		Cheats: []Cheat {
+			{Name: "Test", Start: start},
+		},
+	}
+	if err := scenario.Check(); err == nil || !strings.Contains(err.Error(), "start time must be <= scenario duration") {
+		fmt.Println(err)
+		t.Errorf("cheat issue was not detected")
+	}
+}
+

--- a/driver/parser/parser.go
+++ b/driver/parser/parser.go
@@ -99,8 +99,8 @@ type Auto struct {
 // For example, 2 validators with the same keys started at the same time can be considered
 // an attempt to cheat.
 type Cheat struct {
-	Name      string
-	Start     *float32
+	Name  string
+	Start *float32
 }
 
 // Parse parses a YAML based scenario description from the given reader.

--- a/driver/parser/parser.go
+++ b/driver/parser/parser.go
@@ -32,6 +32,7 @@ type Scenario struct {
 	NumValidators *int          `yaml:"num_validators,omitempty"` // nil == 1
 	Nodes         []Node        `yaml:",omitempty"`
 	Applications  []Application `yaml:",omitempty"`
+	Cheats        []Cheat       `yaml:",omitempty"`
 }
 
 // Node is a configuration for a group of nodes with similar properties.
@@ -92,6 +93,14 @@ type Wave struct {
 type Auto struct {
 	Increase *float32 `yaml:",omitempty"` // increase in non-overload case per second in Tx/s, nil = 1
 	Decrease *float32 `yaml:",omitempty"` // decrease in overload case in percent, nil = 0.2 (=20%)
+}
+
+// Cheat is a configuration to simulate cheating at a particular timing.
+// For example, 2 validators with the same keys started at the same time can be considered
+// an attempt to cheat.
+type Cheat struct {
+	Start     *float32 `yaml:",omitempty"`
+	Name      string
 }
 
 // Parse parses a YAML based scenario description from the given reader.

--- a/driver/parser/parser.go
+++ b/driver/parser/parser.go
@@ -99,8 +99,8 @@ type Auto struct {
 // For example, 2 validators with the same keys started at the same time can be considered
 // an attempt to cheat.
 type Cheat struct {
-	Start     *float32 `yaml:",omitempty"`
 	Name      string
+	Start     *float32
 }
 
 // Parse parses a YAML based scenario description from the given reader.

--- a/driver/parser/parser_test.go
+++ b/driver/parser/parser_test.go
@@ -95,3 +95,18 @@ func TestParseSmallExampleWorks(t *testing.T) {
 		t.Fatalf("parsing of input failed: %v", err)
 	}
 }
+
+var withCheats = smallExample + `
+
+cheats:
+  - name: hello
+    start: 8
+`
+
+func TestParseExampleWithCheats(t *testing.T) {
+	_, err := ParseBytes([]byte(withCheats))
+	if err != nil {
+		t.Fatalf("parsing of input failed: %v", err)
+	}
+}
+

--- a/driver/parser/parser_test.go
+++ b/driver/parser/parser_test.go
@@ -109,4 +109,3 @@ func TestParseExampleWithCheats(t *testing.T) {
 		t.Fatalf("parsing of input failed: %v", err)
 	}
 }
-


### PR DESCRIPTION
Changes related to cheat as found here: https://github.com/Fantom-foundation/Norma/issues/190

Add `cheat` config to Scenario - so that we can simulate cheating to artificially start epoch sealing 
**cheat = start 2 validators with same key at the same time**
  - [x] Add `Cheat` to `Scenario`
      - [x] Add `Cheat`.`Start`  (timing to cheat)
      - [x] Add `Cheat`.`Name` unique name id of the cheat
      - [x] Check that Cheat makes sense (name unique, start <= duration)
  - [x] Driver now add  `cheat` events to event queue on start-up