### PR TITLE
YML Update: node.Genesis

### DIFF
--- a/driver/executor/executor.go
+++ b/driver/executor/executor.go
@@ -192,6 +192,26 @@ func scheduleNodeEvents(node *parser.Node, queue *eventQueue, net driver.Network
 			*instance = newNode
 			return err
 		}))
+		if &node.Genesis != nil {
+			if node.Genesis.Import != nil {
+				queue.add(toSingleEvent(
+					Seconds(*node.Genesis.Import.Start), 
+					fmt.Sprintf("[NOT IMPLEMENTED] node %s is importing genesis from %s.", name, node.Genesis.Import.Path), 
+					func() error {
+						return nil
+					},
+				))
+			}
+			if node.Genesis.Export != nil {
+				queue.add(toSingleEvent(
+					Seconds(*node.Genesis.Export.Start), 
+					fmt.Sprintf("[NOT IMPLEMENTED] node %s is exporting genesis to %s.", name, node.Genesis.Export.Path), 
+					func() error {
+						return nil
+					},
+				))
+			}
+		}
 		queue.add(toSingleEvent(endTime, fmt.Sprintf("stopping node %s", name), func() error {
 			if instance == nil {
 				return nil

--- a/driver/executor/executor.go
+++ b/driver/executor/executor.go
@@ -195,8 +195,8 @@ func scheduleNodeEvents(node *parser.Node, queue *eventQueue, net driver.Network
 		if &node.Genesis != nil {
 			if node.Genesis.Import != nil {
 				queue.add(toSingleEvent(
-					Seconds(*node.Genesis.Import.Start), 
-					fmt.Sprintf("[NOT IMPLEMENTED] node %s is importing genesis from %s.", name, node.Genesis.Import.Path), 
+					Seconds(*node.Genesis.Import.Start),
+					fmt.Sprintf("[NOT IMPLEMENTED] node %s is importing genesis from %s.", name, node.Genesis.Import.Path),
 					func() error {
 						return nil
 					},
@@ -204,8 +204,8 @@ func scheduleNodeEvents(node *parser.Node, queue *eventQueue, net driver.Network
 			}
 			if node.Genesis.Export != nil {
 				queue.add(toSingleEvent(
-					Seconds(*node.Genesis.Export.Start), 
-					fmt.Sprintf("[NOT IMPLEMENTED] node %s is exporting genesis to %s.", name, node.Genesis.Export.Path), 
+					Seconds(*node.Genesis.Export.Start),
+					fmt.Sprintf("[NOT IMPLEMENTED] node %s is exporting genesis to %s.", name, node.Genesis.Export.Path),
 					func() error {
 						return nil
 					},

--- a/driver/parser/check.go
+++ b/driver/parser/check.go
@@ -315,7 +315,7 @@ func checkTimeNodeAlive(start *float32, node *Node, duration float32) error {
 		errs = append(errs, fmt.Errorf("event start must be >= node start (=%fs), is %f", nodeStart, eventStart))
 	}
 	if eventStart > nodeEnd {
-		errs = append(errs, fmt.Errorf("event end must be <= node end (=%fs), is %f", nodeEnd, eventStart))
+		errs = append(errs, fmt.Errorf("event start must be <= node end (=%fs), is %f", nodeEnd, eventStart))
 	}
 	
 	return errors.Join(errs...)

--- a/driver/parser/check.go
+++ b/driver/parser/check.go
@@ -19,10 +19,10 @@ package parser
 import (
 	"errors"
 	"fmt"
-	"regexp"
-	"strings"
 	"os"
 	"path/filepath"
+	"regexp"
+	"strings"
 
 	"github.com/Fantom-foundation/Norma/load/app"
 )
@@ -294,7 +294,7 @@ func checkTimeInterval(start, end *float32, duration float32) error {
 	return errors.Join(errs...)
 }
 
-//checkTimeNodeAlive is a utility function checking if an event happens during the start/end of a node.
+// checkTimeNodeAlive is a utility function checking if an event happens during the start/end of a node.
 func checkTimeNodeAlive(start *float32, node *Node, duration float32) error {
 	nodeStart := float32(0.0)
 	if node.Start != nil {
@@ -317,7 +317,6 @@ func checkTimeNodeAlive(start *float32, node *Node, duration float32) error {
 	if eventStart > nodeEnd {
 		errs = append(errs, fmt.Errorf("event start must be <= node end (=%fs), is %f", nodeEnd, eventStart))
 	}
-	
+
 	return errors.Join(errs...)
 }
-

--- a/driver/parser/check.go
+++ b/driver/parser/check.go
@@ -94,13 +94,13 @@ func (n *Node) Check(scenario *Scenario) error {
 		if err := isGenesisFile(n.Genesis.Import.Path); err != nil {
 			errs = append(errs, err)
 		}
-		if err := checkTimeInterval(n.Genesis.Import.Start, nil, scenario.Duration); err != nil {
+		if err := checkTimeNodeAlive(n.Genesis.Import.Start, n, scenario.Duration); err != nil {
 			errs = append(errs, err)
 		}
 	}
 
 	if n.Genesis.Export != nil {
-		if err := checkTimeInterval(n.Genesis.Export.Start, nil, scenario.Duration); err != nil {
+		if err := checkTimeNodeAlive(n.Genesis.Export.Start, n, scenario.Duration); err != nil {
 			errs = append(errs, err)
 		}
 	}
@@ -293,3 +293,31 @@ func checkTimeInterval(start, end *float32, duration float32) error {
 	}
 	return errors.Join(errs...)
 }
+
+//checkTimeNodeAlive is a utility function checking if an event happens during the start/end of a node.
+func checkTimeNodeAlive(start *float32, node *Node, duration float32) error {
+	nodeStart := float32(0.0)
+	if node.Start != nil {
+		nodeStart = *node.Start
+	}
+	nodeEnd := duration
+	if node.End != nil {
+		nodeEnd = *node.End
+	}
+
+	eventStart := nodeStart
+	if start != nil {
+		eventStart = *start
+	}
+
+	errs := []error{}
+	if eventStart < nodeStart {
+		errs = append(errs, fmt.Errorf("event start must be >= node start (=%fs), is %f", nodeStart, eventStart))
+	}
+	if eventStart > nodeEnd {
+		errs = append(errs, fmt.Errorf("event end must be <= node end (=%fs), is %f", nodeEnd, eventStart))
+	}
+	
+	return errors.Join(errs...)
+}
+

--- a/driver/parser/check_test.go
+++ b/driver/parser/check_test.go
@@ -467,10 +467,10 @@ func TestScenario_NodeGenesisIssuesAreDetected(t *testing.T) {
 	scenario := Scenario{
 		Name:     "Test",
 		Duration: 60,
-		Nodes:    []Node{
+		Nodes: []Node{
 			{Genesis: Genesis{Import: &GenesisTarget{
-				Start: start, 
-				Path: "/does/not/exist.g",
+				Start: start,
+				Path:  "/does/not/exist.g",
 			}}},
 		},
 	}
@@ -481,10 +481,10 @@ func TestScenario_NodeGenesisIssuesAreDetected(t *testing.T) {
 	scenario = Scenario{
 		Name:     "Test",
 		Duration: 60,
-		Nodes:    []Node{
+		Nodes: []Node{
 			{Genesis: Genesis{Import: &GenesisTarget{
-				Start: start, 
-				Path: "",
+				Start: start,
+				Path:  "",
 			}}},
 		},
 	}
@@ -495,10 +495,10 @@ func TestScenario_NodeGenesisIssuesAreDetected(t *testing.T) {
 	scenario = Scenario{
 		Name:     "Test",
 		Duration: 60,
-		Nodes:    []Node{
+		Nodes: []Node{
 			{Genesis: Genesis{Import: &GenesisTarget{
-				Start: start, 
-				Path: "/does/exist.notg",
+				Start: start,
+				Path:  "/does/exist.notg",
 			}}},
 		},
 	}
@@ -510,10 +510,10 @@ func TestScenario_NodeGenesisIssuesAreDetected(t *testing.T) {
 	scenario = Scenario{
 		Name:     "Test",
 		Duration: 60,
-		Nodes:    []Node{
+		Nodes: []Node{
 			{Genesis: Genesis{Import: &GenesisTarget{
-				Start: start, 
-				Path: "/does/exist.g",
+				Start: start,
+				Path:  "/does/exist.g",
 			}}},
 		},
 	}

--- a/driver/parser/check_test.go
+++ b/driver/parser/check_test.go
@@ -517,7 +517,7 @@ func TestScenario_NodeGenesisIssuesAreDetected(t *testing.T) {
 			}}},
 		},
 	}
-	if err := scenario.Check(); err == nil || !strings.Contains(err.Error(), "event end must be <= node end") {
+	if err := scenario.Check(); err == nil || !strings.Contains(err.Error(), "event start must be <= node end") {
 		t.Errorf("genesis import/export outside duration but issue was not detected")
 	}
 }

--- a/driver/parser/check_test.go
+++ b/driver/parser/check_test.go
@@ -459,3 +459,65 @@ func TestScenario_CheatIssuesAreDetected(t *testing.T) {
 		t.Errorf("cheat issue was not detected")
 	}
 }
+
+func TestScenario_NodeGenesisIssuesAreDetected(t *testing.T) {
+	start := new(float32)
+
+	*start = 30
+	scenario := Scenario{
+		Name:     "Test",
+		Duration: 60,
+		Nodes:    []Node{
+			{Genesis: Genesis{Import: &GenesisTarget{
+				Start: start, 
+				Path: "/does/not/exist.g",
+			}}},
+		},
+	}
+	if err := scenario.Check(); err == nil || !strings.Contains(err.Error(), "provided genesis file does not exist") {
+		t.Errorf("genesis does not exist but issue was not detected")
+	}
+
+	scenario = Scenario{
+		Name:     "Test",
+		Duration: 60,
+		Nodes:    []Node{
+			{Genesis: Genesis{Import: &GenesisTarget{
+				Start: start, 
+				Path: "",
+			}}},
+		},
+	}
+	if err := scenario.Check(); err == nil || !strings.Contains(err.Error(), "provided path to genesis file is nil") {
+		t.Errorf("targeted path was nil but issue was not detected")
+	}
+
+	scenario = Scenario{
+		Name:     "Test",
+		Duration: 60,
+		Nodes:    []Node{
+			{Genesis: Genesis{Import: &GenesisTarget{
+				Start: start, 
+				Path: "/does/exist.notg",
+			}}},
+		},
+	}
+	if err := scenario.Check(); err == nil || !strings.Contains(err.Error(), "provided path is not a genesis file") {
+		t.Errorf("targeted file is not a genesis but issue was not detected")
+	}
+
+	*start = 70
+	scenario = Scenario{
+		Name:     "Test",
+		Duration: 60,
+		Nodes:    []Node{
+			{Genesis: Genesis{Import: &GenesisTarget{
+				Start: start, 
+				Path: "/does/exist.g",
+			}}},
+		},
+	}
+	if err := scenario.Check(); err == nil || !strings.Contains(err.Error(), "start time must be <= scenario duration") {
+		t.Errorf("genesis import/export outside duration but issue was not detected")
+	}
+}

--- a/driver/parser/check_test.go
+++ b/driver/parser/check_test.go
@@ -517,7 +517,7 @@ func TestScenario_NodeGenesisIssuesAreDetected(t *testing.T) {
 			}}},
 		},
 	}
-	if err := scenario.Check(); err == nil || !strings.Contains(err.Error(), "start time must be <= scenario duration") {
+	if err := scenario.Check(); err == nil || !strings.Contains(err.Error(), "event end must be <= node end") {
 		t.Errorf("genesis import/export outside duration but issue was not detected")
 	}
 }

--- a/driver/parser/parser.go
+++ b/driver/parser/parser.go
@@ -46,7 +46,7 @@ type Node struct {
 	Start     *float32 `yaml:",omitempty"` // nil is interpreted as 0
 	End       *float32 `yaml:",omitempty"` // nil is interpreted as end-of-scenario
 	Genesis   Genesis  `yaml:",omitempty"`
-  Client    ClientType
+	Client    ClientType
 }
 
 // Genesis is an optional configuration for a node.

--- a/driver/parser/parser.go
+++ b/driver/parser/parser.go
@@ -48,21 +48,20 @@ type Node struct {
 	Genesis   Genesis  `yaml:",omitempty"`
 }
 
-
 // Genesis is an optional configuration for a node.
-// GenesisImport will stop the client and restart the client with the target 
+// GenesisImport will stop the client and restart the client with the target
 // genesis file at the provided time.
 // GenesisExport will stop the client, export the genesis file and restart the client.
 type Genesis struct {
 	// Only one of the next fields may be set.
-	Import    *GenesisTarget
-	Export    *GenesisTarget 
+	Import *GenesisTarget
+	Export *GenesisTarget
 }
 
 // GenesisTarget is the configuration to specify the target genesis file and the timing.
 type GenesisTarget struct {
-	Start     *float32
-	Path      string
+	Start *float32
+	Path  string
 }
 
 // Application is a load generator in the simulated network. Each application defines

--- a/driver/parser/parser.go
+++ b/driver/parser/parser.go
@@ -45,6 +45,24 @@ type Node struct {
 	Instances *int     `yaml:",omitempty"` // nil is interpreted as 1
 	Start     *float32 `yaml:",omitempty"` // nil is interpreted as 0
 	End       *float32 `yaml:",omitempty"` // nil is interpreted as end-of-scenario
+	Genesis   Genesis  `yaml:",omitempty"`
+}
+
+
+// Genesis is an optional configuration for a node.
+// GenesisImport will stop the client and restart the client with the target 
+// genesis file at the provided time.
+// GenesisExport will stop the client, export the genesis file and restart the client.
+type Genesis struct {
+	// Only one of the next fields may be set.
+	Import    *GenesisTarget
+	Export    *GenesisTarget 
+}
+
+// GenesisTarget is the configuration to specify the target genesis file and the timing.
+type GenesisTarget struct {
+	Start     *float32
+	Path      string
 }
 
 // Application is a load generator in the simulated network. Each application defines

--- a/driver/parser/parser_test.go
+++ b/driver/parser/parser_test.go
@@ -105,6 +105,49 @@ cheats:
 
 func TestParseExampleWithCheats(t *testing.T) {
 	_, err := ParseBytes([]byte(withCheats))
+}
+
+// withGenesis extends the small scenario with genesis option.
+var withGenesis = `
+name: Small Test With Genesis
+num_validators: 5
+nodes:
+  - name: A
+    instances: 10
+    features:
+      - validator
+      - archive
+    start: 5
+    end: 7.5
+    genesis:
+      import:
+        start: 3
+        path: /path/to/genesis
+
+applications:
+  - name: lottery
+    instances: 10
+    start: 7
+    end: 10
+    rate:
+      constant: 8
+
+  - name: my_coin
+    rate:
+      slope:
+        start: 5
+        increment: 1
+
+  - name: game
+    rate:
+      wave:
+        min: 10
+        max: 20
+        period: 120
+`
+
+func TestParseWithGenesisWorks(t *testing.T) {
+	_, err := ParseBytes([]byte(withGenesis))
 	if err != nil {
 		t.Fatalf("parsing of input failed: %v", err)
 	}

--- a/driver/parser/parser_test.go
+++ b/driver/parser/parser_test.go
@@ -105,6 +105,9 @@ cheats:
 
 func TestParseExampleWithCheats(t *testing.T) {
 	_, err := ParseBytes([]byte(withCheats))
+	if err != nil {
+		t.Fatalf("parsing of input failed: %v", err)
+	}
 }
 
 // withGenesis extends the small scenario with genesis option.


### PR DESCRIPTION
Changes related to node.Genesis as found here: https://github.com/Fantom-foundation/Norma/issues/190

Add `genesis` config to Node - so that we can schedule genesis import to/export from a node.
  - [x] Add `Genesis` to `Node`
      - [x] Add `Genesis`.`Import` [Start, Name (path to input genesis file)]
      - [x] Add `Genesis`.`Export` [Start, Name (path to output genesis file)]
      - [x] Add Check so that 1. Path exists and is a genesis 2. Start <= duration
  - [x] Driver now add genesis events to event queue on start-up