### PR TITLE
Update Sonic Version

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "go-opera-norma"]
 	path = client
-	url = git@github.com:Fantom-foundation/go-opera-norma.git
+	url =  https://github.com/Fantom-foundation/Sonic.git


### PR DESCRIPTION
- Update to latest sonic version
- submodule now uses `https://github.com/Fantom-foundation/Sonic.git` instead of `git@github.com:Fantom-foundation/Sonic.git`