### PR TITLE
Fix JSONArgsRecommended warning on make

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,4 +48,4 @@ EXPOSE 18545
 EXPOSE 18546
 
 COPY scripts/run_sonic.sh .
-CMD /bin/bash run_sonic.sh
+CMD ["/bin/bash", "run_sonic.sh"]


### PR DESCRIPTION
The following warning is found when running `make`
```
 1 warning found (use --debug to expand):
 - JSONArgsRecommended: JSON arguments recommended for CMD to prevent unintended behavior related to OS signals (line 51)
```

Further discussion:
https://docs.docker.com/reference/build-checks/json-args-recommended/

This may be why the containers don't respond to `SIGTERM` and `SIGKILL` correctly.
