### PR TITLE
Bind sonic's IPC to host

### DIFF
--- a/driver/docker/docker.go
+++ b/driver/docker/docker.go
@@ -77,6 +77,7 @@ type ContainerConfig struct {
 	Environment     map[string]string
 	Entrypoint      []string // Entrypoint to run when starting the container. Optional.
 	Network         *Network // Docker network to join, nil to join bridge network
+	Binds		[]string // Binding of local path to path in docker
 }
 
 // NewClient creates a new client facilitating the creation of Docker
@@ -152,17 +153,24 @@ func (c *Client) Start(config *ContainerConfig) (*Container, error) {
 		}}
 	}
 
-	resp, err := c.cli.ContainerCreate(context.Background(), &container.Config{
-		Image:      config.ImageName,
-		Tty:        false,
-		Env:        envVars,
-		Entrypoint: config.Entrypoint,
-		Labels: map[string]string{
-			objectsLabel: "true",
-		},
-	}, &container.HostConfig{
-		PortBindings: portMapping,
-	}, nil, nil, "")
+	resp, err := c.cli.ContainerCreate(
+		context.Background(), 
+		&container.Config{
+			Image:      config.ImageName,
+			Tty:        false,
+			Env:        envVars,
+			Entrypoint: config.Entrypoint,
+			Labels: map[string]string{
+				objectsLabel: "true",
+			},
+		}, 
+		&container.HostConfig{
+			PortBindings: portMapping,
+			Binds: config.Binds,
+		}, 
+		nil, nil, "",
+	)
+
 	if err != nil {
 		return nil, err
 	}

--- a/driver/docker/docker.go
+++ b/driver/docker/docker.go
@@ -77,7 +77,7 @@ type ContainerConfig struct {
 	Environment     map[string]string
 	Entrypoint      []string // Entrypoint to run when starting the container. Optional.
 	Network         *Network // Docker network to join, nil to join bridge network
-	Binds		[]string // Binding of local path to path in docker
+	Binds           []string // Binding of local path to path in docker
 }
 
 // NewClient creates a new client facilitating the creation of Docker
@@ -154,7 +154,7 @@ func (c *Client) Start(config *ContainerConfig) (*Container, error) {
 	}
 
 	resp, err := c.cli.ContainerCreate(
-		context.Background(), 
+		context.Background(),
 		&container.Config{
 			Image:      config.ImageName,
 			Tty:        false,
@@ -163,11 +163,11 @@ func (c *Client) Start(config *ContainerConfig) (*Container, error) {
 			Labels: map[string]string{
 				objectsLabel: "true",
 			},
-		}, 
+		},
 		&container.HostConfig{
 			PortBindings: portMapping,
-			Binds: config.Binds,
-		}, 
+			Binds:        config.Binds,
+		},
 		nil, nil, "",
 	)
 

--- a/driver/docker/docker.go
+++ b/driver/docker/docker.go
@@ -128,7 +128,6 @@ func Purge() error {
 			return err
 		}
 	}
-	
 
 	// get all networks created by norma
 	networks, err := cli.listNetworks()

--- a/driver/docker/docker.go
+++ b/driver/docker/docker.go
@@ -116,12 +116,19 @@ func Purge() error {
 	}
 
 	// get all volumes created by norma
-	_, err = cli.listVolumes()
+	volumess, err = cli.listVolumes()
 	if err != nil {
 		return err
 	}
 
-	// TODO: remove all volumes
+	// remove all volumes
+	for _, v := range volumes {
+		err := cli.cli.VolumeRemove(context.Background(), v.ClusterVolume.Info.VolumeID, true)
+		if err != nil {
+			return err
+		}
+	}
+	
 
 	// get all networks created by norma
 	networks, err := cli.listNetworks()

--- a/driver/docker/docker.go
+++ b/driver/docker/docker.go
@@ -116,7 +116,7 @@ func Purge() error {
 	}
 
 	// get all volumes created by norma
-	volumess, err = cli.listVolumes()
+	volumes, err := cli.listVolumes()
 	if err != nil {
 		return err
 	}

--- a/driver/docker/docker.go
+++ b/driver/docker/docker.go
@@ -77,9 +77,9 @@ type ContainerConfig struct {
 	ShutdownTimeout *time.Duration
 	PortForwarding  map[network.Port]network.Port // Container Port => Host Port
 	Environment     map[string]string
-	Entrypoint      []string // Entrypoint to run when starting the container. Optional.
-	Network         *Network // Docker network to join, nil to join bridge network
-	Mounts         map[string]string // localname:/path/in/docker
+	Entrypoint      []string          // Entrypoint to run when starting the container. Optional.
+	Network         *Network          // Docker network to join, nil to join bridge network
+	Mounts          map[string]string // localname:/path/in/docker
 }
 
 // NewClient creates a new client facilitating the creation of Docker
@@ -167,7 +167,7 @@ func (c *Client) Start(config *ContainerConfig) (*Container, error) {
 	mounts := []mount.Mount{}
 	for localName, pathInDocker := range config.Mounts {
 		mounts = append(mounts, mount.Mount{
-			Type: mount.TypeVolume,
+			Type:   mount.TypeVolume,
 			Source: localName,
 			Target: pathInDocker,
 		})
@@ -186,7 +186,7 @@ func (c *Client) Start(config *ContainerConfig) (*Container, error) {
 		},
 		&container.HostConfig{
 			PortBindings: portMapping,
-			Mounts: mounts,
+			Mounts:       mounts,
 		},
 		nil, nil, "",
 	)
@@ -252,7 +252,6 @@ func (c *Client) CreateVolume(name string) (*volume.Volume, error) {
 	}
 	return &vol, nil
 }
-
 
 // Hostname returns the hostname of the Container. In this case it is the ID of the
 // Docker Container.
@@ -452,7 +451,6 @@ func (c *Client) listVolumes() ([]*volume.Volume, error) {
 	}
 	return resp.Volumes, nil
 }
-
 
 // getObjectsLabelFilter returns a filter for the objects label.
 func getObjectsLabelFilter() filters.KeyValuePair {

--- a/driver/network/local/local.go
+++ b/driver/network/local/local.go
@@ -77,7 +77,7 @@ type LocalNetwork struct {
 }
 
 var LocalVolumes = map[string]string{
-	"ipc":"/datadir/ipc",
+	"ipc": "/datadir/ipc",
 }
 
 func NewLocalNetwork(config *driver.NetworkConfig) (*LocalNetwork, error) {
@@ -91,7 +91,7 @@ func NewLocalNetwork(config *driver.NetworkConfig) (*LocalNetwork, error) {
 		return nil, fmt.Errorf("failed to create bridge network; %v", err)
 	}
 
-	for localName, _ := range LocalVolumes {
+	for localName := range LocalVolumes {
 		_, err := client.CreateVolume(localName)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create volume %s; %v", localName, err)
@@ -130,11 +130,11 @@ func NewLocalNetwork(config *driver.NetworkConfig) (*LocalNetwork, error) {
 			defer wg.Done()
 			validatorId := i + 1
 			nodeConfig := node.OperaNodeConfig{
-				ValidatorId:       &validatorId,
-				NetworkConfig:     config,
-				Label:             fmt.Sprintf("_validator-%d", validatorId),
-				VmImplementation:  config.VmImplementation,
-				Mounts: LocalVolumes,
+				ValidatorId:      &validatorId,
+				NetworkConfig:    config,
+				Label:            fmt.Sprintf("_validator-%d", validatorId),
+				VmImplementation: config.VmImplementation,
+				Mounts:           LocalVolumes,
 			}
 			net.validators[i], errs[i] = net.createNode(&nodeConfig)
 		}()

--- a/driver/network/local/local.go
+++ b/driver/network/local/local.go
@@ -119,10 +119,11 @@ func NewLocalNetwork(config *driver.NetworkConfig) (*LocalNetwork, error) {
 			defer wg.Done()
 			validatorId := i + 1
 			nodeConfig := node.OperaNodeConfig{
-				ValidatorId:      &validatorId,
-				NetworkConfig:    config,
-				Label:            fmt.Sprintf("_validator-%d", validatorId),
-				VmImplementation: config.VmImplementation,
+				ValidatorId:       &validatorId,
+				NetworkConfig:     config,
+				Label:             fmt.Sprintf("_validator-%d", validatorId),
+				VmImplementation:  config.VmImplementation,
+				IpcBindingEnabled: true,
 			}
 			net.validators[i], errs[i] = net.createNode(&nodeConfig)
 		}()

--- a/driver/network/local/local.go
+++ b/driver/network/local/local.go
@@ -76,6 +76,8 @@ type LocalNetwork struct {
 	rpcWorkerPool *rpc.RpcWorkerPool
 }
 
+// LocalVolumes is a list of mapping between local volumes to path in docker.
+// Format: localname:/path/in/docker
 var LocalVolumes = map[string]string{
 	"ipc": "/datadir/ipc",
 }

--- a/driver/node/opera.go
+++ b/driver/node/opera.go
@@ -107,7 +107,7 @@ func StartOperaDockerNode(client *docker.Client, dn *docker.Network, config *Ope
 
 	bindings := []string{}
 	if config.IpcBindingEnabled {
-		bindings = append(bindings, 
+		bindings = append(bindings,
 			fmt.Sprintf("%s.ipc:/datadir/opera.ipc", config.Label),
 		)
 	}
@@ -132,7 +132,7 @@ func StartOperaDockerNode(client *docker.Client, dn *docker.Network, config *Ope
 				"VM_IMPL":          config.VmImplementation,
 			},
 			Network: dn,
-			Binds: bindings,
+			Binds:   bindings,
 		})
 	})
 	if err != nil {

--- a/driver/node/opera.go
+++ b/driver/node/opera.go
@@ -125,7 +125,7 @@ func StartOperaDockerNode(client *docker.Client, dn *docker.Network, config *Ope
 				"VM_IMPL":          config.VmImplementation,
 			},
 			Network: dn,
-			Mounts: config.Mounts,
+			Mounts:  config.Mounts,
 		})
 	})
 	if err != nil {

--- a/driver/node/opera.go
+++ b/driver/node/opera.go
@@ -108,7 +108,7 @@ func StartOperaDockerNode(client *docker.Client, dn *docker.Network, config *Ope
 	bindings := []string{}
 	if config.IpcBindingEnabled {
 		bindings = append(bindings, 
-			fmt.Sprintf("ipc/%s.ipc:/datadir/opera.ipc", config.Label),
+			fmt.Sprintf("%s.ipc:/datadir/opera.ipc", config.Label),
 		)
 	}
 


### PR DESCRIPTION
Currently, there is an IPC located at the default path `/datadir/opera.ipc`.
Binding this so that host can access them will help with manual debugging. In the future, it will also help to facilitate decoupling RPC communication and Norma bookkeeping.

TODO: 
- Clean up configuration - move away from hard-coding local path and default ipc path
- Create test to ensure that IPC is indeed exposed.