### PR TITLE
Add delay time to logging events

### DIFF
--- a/driver/executor/clock.go
+++ b/driver/executor/clock.go
@@ -36,6 +36,8 @@ type Clock interface {
 
 	// NotifyAt creates a channel sending a message when the given time is reached.
 	NotifyAt(Time) <-chan Time
+
+	Delay(Time) time.Duration
 }
 
 // Time is used to model time in a scenario, relative to the start time. Thus,
@@ -98,6 +100,10 @@ func (c *SimClock) NotifyAt(time Time) <-chan Time {
 	return ch
 }
 
+func (c *SimClock) Delay(deadline Time) time.Duration {
+	return time.Duration(c.now - deadline)
+}
+
 // WallTimeClock is a clock aiming to follow real wall-clock time. It is
 // intended to be used when running scenarios for actual evaluations.
 type WallTimeClock struct {
@@ -135,4 +141,8 @@ func (c *WallTimeClock) NotifyAt(deadline Time) <-chan Time {
 		res <- c.Now()
 	}
 	return res
+}
+
+func (c *WallTimeClock) Delay(deadline Time) time.Duration {
+	return time.Duration(c.Now() - deadline)
 }

--- a/driver/executor/executor.go
+++ b/driver/executor/executor.go
@@ -21,6 +21,7 @@ import (
 	"log"
 	"os"
 	"os/signal"
+	"time"
 
 	"github.com/Fantom-foundation/Norma/driver"
 	"github.com/Fantom-foundation/Norma/driver/parser"
@@ -80,7 +81,13 @@ func Run(clock Clock, network driver.Network, scenario *parser.Scenario) error {
 			return fmt.Errorf("aborted by user")
 		}
 
-		log.Printf("processing '%s' at time %v ...\n", event.name(), event.time())
+		delay := clock.Delay(event.time())
+		// display delay if it exceeds over 1 second
+		if delay > time.Second {
+			log.Printf("processing '%s' at time %v (delay: %v)...\n", event.name(), event.time(), delay.Round(time.Second/10).Seconds())
+		} else {
+			log.Printf("processing '%s' at time %v...\n", event.name(), event.time())
+		}
 
 		// Execute the event and schedule successors.
 		successors, err := event.run()


### PR DESCRIPTION
Add delay time to output, if delay exceeds 1 second. To allow tracing of shifted events time.

Preview:
```
processing 'deploying contract app load-0' at time 5.0 (delay: 20.7)...
```