### PR TITLE
Bugfix for PR218

### DIFF
--- a/driver/network_mock.go
+++ b/driver/network_mock.go
@@ -14,7 +14,7 @@ import (
 
 	rpc "github.com/Fantom-foundation/Norma/driver/rpc"
 	types "github.com/ethereum/go-ethereum/core/types"
-	gomock "go.uber.org/mock/gomock"
+	gomock "github.com/golang/mock/gomock"
 )
 
 // MockNetwork is a mock of Network interface.

--- a/load/app/app_test.go
+++ b/load/app/app_test.go
@@ -45,7 +45,7 @@ func TestGenerators(t *testing.T) {
 		t.Fatal("unable to connect the the rpc")
 	}
 
-	primaryAccount, err := app.NewAccount(0, PrivateKey, FakeNetworkID)
+	primaryAccount, err := app.NewAccount(0, PrivateKey, nil, FakeNetworkID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -61,7 +61,7 @@ func TestGenerators(t *testing.T) {
 		erc20app, err := app.NewERC20Application(rpcClient, primaryAccount, 1, 0, 0)
 		if err != nil {
 			t.Fatal(err)
-		}
+		}a
 		testGenerator(t, erc20app, rpcClient)
 	})
 	t.Run("Store", func(t *testing.T) {

--- a/load/controller/rpc_test.go
+++ b/load/controller/rpc_test.go
@@ -44,7 +44,7 @@ func TestTrafficGenerating(t *testing.T) {
 		t.Fatal("unable to connect the the rpc")
 	}
 
-	primaryAccount, err := app.NewAccount(0, PrivateKey, FakeNetworkID)
+	primaryAccount, err := app.NewAccount(0, PrivateKey, nil, FakeNetworkID)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
- `gomock` reverted to previously used (from `github `and not `go.uber...`)
- test for app/rpc now uses updated new account func