### PR TITLE
[QoL] RT.jenkinsfile now collect monitoring as artifact

### DIFF
--- a/RT.jenkinsfile
+++ b/RT.jenkinsfile
@@ -80,12 +80,12 @@ pipeline {
 			}
 
 			steps {
-				build/norma run --label a1 release_testing/a1.ValRpcObs.yml
+				build/norma run --label a1 -o . release_testing/a1.ValRpcObs.yml
 			}
 
 			post {
 				success {
-					dir('/tmp/norma_data_a1_*') {
+					dir('./norma_data_a1_latest') {
 						archiveArtifacts artifacts: '**'
 					}
 				}
@@ -101,12 +101,12 @@ pipeline {
 			}
 
 			steps {
-				build/norma run --label a2 release_testing/a2.MultSonicVer.yml
+				build/norma run --label a2 -o . release_testing/a2.MultSonicVer.yml
 			}
 
 			post {
 				success {
-					dir('/tmp/norma_data_a2_*') {
+					dir('./norma_data_a2_latest') {
 						archiveArtifacts artifacts: '**'
 					}
 				}
@@ -123,12 +123,12 @@ pipeline {
 			}
 
 			steps {
-				build/norma run --label b1 release_testing/b1.NewValMidRun.yml
+				build/norma run --label b1 -o . release_testing/b1.NewValMidRun.yml
 			}
 
 			post {
 				success {
-					dir('/tmp/norma_data_b1_*') {
+					dir('./norma_data_b1_latest') {
 						archiveArtifacts artifacts: '**'
 					}
 				}
@@ -144,12 +144,12 @@ pipeline {
 			}
 
 			steps {
-				build/norma run --label b2 release_testing/b2.KillValMidRun.yml
+				build/norma run --label b2 -o . release_testing/b2.KillValMidRun.yml
 			}
 
 			post {
 				success {
-					dir('/tmp/norma_data_b2_*') {
+					dir('./norma_data_b2_latest') {
 						archiveArtifacts artifacts: '**'
 					}
 				}
@@ -165,12 +165,12 @@ pipeline {
 			}
 
 			steps {
-				build/norma run --label b3 release_testing/b3.RestartValMidRun.yml
+				build/norma run --label b3 -o . release_testing/b3.RestartValMidRun.yml
 			}
 
 			post {
 				success {
-					dir('/tmp/norma_data_b3_*') {
+					dir('./norma_data_b3_latest') {
 						archiveArtifacts artifacts: '**'
 					}
 				}
@@ -186,12 +186,12 @@ pipeline {
 			}
 
 			steps {
-				build/norma run --label b4 release_testing/b4.ValCheatMustSealEpoch.yml
+				build/norma run --label b4 -o . release_testing/b4.ValCheatMustSealEpoch.yml
 			}
 
 			post {
 				success {
-					dir('/tmp/norma_data_b4_*') {
+					dir('./norma_data_b4_latest') {
 						archiveArtifacts artifacts: '**'
 					}
 				}
@@ -207,12 +207,12 @@ pipeline {
 			}
 
 			steps {
-				build/norma run --label b5 release_testing/b5.ValsBlackout.yml
+				build/norma run --label b5 -o . release_testing/b5.ValsBlackout.yml
 			}
 			
 			post {
 				success {
-					dir('/tmp/norma_data_b5_*') {
+					dir('./norma_data_b5_latest') {
 						archiveArtifacts artifacts: '**'
 					}
 				}
@@ -228,12 +228,12 @@ pipeline {
 			}
 
 			steps {
-				build/norma run --label c1 release_testing/c1.RpcRequests.yml
+				build/norma run --label c1 -o . release_testing/c1.RpcRequests.yml
 			}
 
 			post {
 				success {
-					dir('/tmp/norma_data_c1_*') {
+					dir('./norma_data_c1_latest') {
 						archiveArtifacts artifacts: '**'
 					}
 				}

--- a/RT.jenkinsfile
+++ b/RT.jenkinsfile
@@ -64,7 +64,9 @@ pipeline {
 
 			post {
 				success {
-					buildSuccess = true
+					script {
+						buildSuccess = true
+					}
 				}
 			}
 		}
@@ -78,7 +80,15 @@ pipeline {
 			}
 
 			steps {
-				build/norma run release_testing/a1.ValRpcObs.yml
+				build/norma run --label a1 release_testing/a1.ValRpcObs.yml
+			}
+
+			post {
+				success {
+					dir('/tmp/norma_data_a1_*') {
+						archiveArtifacts artifacts: '**'
+					}
+				}
 			}
 		}
 
@@ -91,8 +101,17 @@ pipeline {
 			}
 
 			steps {
-				build/norma run release_testing/a2.MultSonicVer.yml
+				build/norma run --label a2 release_testing/a2.MultSonicVer.yml
 			}
+
+			post {
+				success {
+					dir('/tmp/norma_data_a2_*') {
+						archiveArtifacts artifacts: '**'
+					}
+				}
+			}
+
 		}
 
 		stage('Test B1 - NewValMidRun') {
@@ -104,7 +123,15 @@ pipeline {
 			}
 
 			steps {
-				build/norma run release_testing/b1.NewValMidRun.yml
+				build/norma run --label b1 release_testing/b1.NewValMidRun.yml
+			}
+
+			post {
+				success {
+					dir('/tmp/norma_data_b1_*') {
+						archiveArtifacts artifacts: '**'
+					}
+				}
 			}
 		}
 
@@ -117,7 +144,15 @@ pipeline {
 			}
 
 			steps {
-				build/norma run release_testing/b2.KillValMidRun.yml
+				build/norma run --label b2 release_testing/b2.KillValMidRun.yml
+			}
+
+			post {
+				success {
+					dir('/tmp/norma_data_b2_*') {
+						archiveArtifacts artifacts: '**'
+					}
+				}
 			}
 		}
 
@@ -130,7 +165,15 @@ pipeline {
 			}
 
 			steps {
-				build/norma run release_testing/b3.RestartValMidRun.yml
+				build/norma run --label b3 release_testing/b3.RestartValMidRun.yml
+			}
+
+			post {
+				success {
+					dir('/tmp/norma_data_b3_*') {
+						archiveArtifacts artifacts: '**'
+					}
+				}
 			}
 		}
 
@@ -143,7 +186,15 @@ pipeline {
 			}
 
 			steps {
-				build/norma run release_testing/b4.ValCheatMustSealEpoch.yml
+				build/norma run --label b4 release_testing/b4.ValCheatMustSealEpoch.yml
+			}
+
+			post {
+				success {
+					dir('/tmp/norma_data_b4_*') {
+						archiveArtifacts artifacts: '**'
+					}
+				}
 			}
 		}
 
@@ -156,7 +207,15 @@ pipeline {
 			}
 
 			steps {
-				build/norma run release_testing/b5.ValsBlackout.yml
+				build/norma run --label b5 release_testing/b5.ValsBlackout.yml
+			}
+			
+			post {
+				success {
+					dir('/tmp/norma_data_b5_*') {
+						archiveArtifacts artifacts: '**'
+					}
+				}
 			}
 		}
 
@@ -169,8 +228,17 @@ pipeline {
 			}
 
 			steps {
-				build/norma run release_testing/c1.RpcRequests.yml
+				build/norma run --label c1 release_testing/c1.RpcRequests.yml
 			}
+
+			post {
+				success {
+					dir('/tmp/norma_data_c1_*') {
+						archiveArtifacts artifacts: '**'
+					}
+				}
+			}
+
 		}
 	}
 }

--- a/driver/norma/run.go
+++ b/driver/norma/run.go
@@ -153,7 +153,7 @@ func run(ctx *cli.Context) (err error) {
 
 	// create symlink as qol (_latest => _####) where #### is the randomly generated name
 	symlink := filepath.Join(filepath.Dir(outputDir), fmt.Sprintf("norma_data_%s_latest", label))
-	if _, err := os.LStat(symlink); err == nil {
+	if _, err := os.Lstat(symlink); err == nil {
 		os.Remove(symlink)
 	}
 	os.Symlink(outputDir, symlink)

--- a/driver/norma/run.go
+++ b/driver/norma/run.go
@@ -23,6 +23,8 @@ import (
 	"sort"
 	"strings"
 	"time"
+	"ioutil"
+	"path/filepath"
 
 	"github.com/Fantom-foundation/Norma/driver/checking"
 
@@ -141,6 +143,17 @@ func run(ctx *cli.Context) (err error) {
 		return err
 	}
 	fmt.Printf("Monitoring data is written to %v\n", outputDir)
+
+	// Copy scenario yml to outputDir as well to provide context
+	data, err := ioutil.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	err = ioutil.WriteFile(filepath.Join(outputDir, filepath.Base(path)), data, 0644)
+	if err != nil {
+		return err
+	}
+
 	clock := executor.NewWallTimeClock()
 
 	// Startup network.

--- a/driver/norma/run.go
+++ b/driver/norma/run.go
@@ -18,13 +18,13 @@ package main
 
 import (
 	"fmt"
+	"io/ioutil"
 	"log"
 	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 	"time"
-	"ioutil"
-	"path/filepath"
 
 	"github.com/Fantom-foundation/Norma/driver/checking"
 

--- a/driver/norma/run.go
+++ b/driver/norma/run.go
@@ -149,7 +149,7 @@ func run(ctx *cli.Context) (err error) {
 	// if not configured, default to /tmp/norma_data_<label>_<timestamp> else /configured/path/norma_data_<l>_<t>
 	outputDir, err := os.MkdirTemp(ctx.String(outputDirectory.Name), fmt.Sprintf("norma_data_%s_", label))
 	if err != nil {
-		return fmt.Errorf("Couldn't create temp dir for output; %s", err)
+		return fmt.Errorf("Couldn't create temp dir for output; %w", err)
 	}
 
 	// create symlink as qol (_latest => _####) where #### is the randomly generated name

--- a/driver/norma/run.go
+++ b/driver/norma/run.go
@@ -57,6 +57,7 @@ var runCommand = cli.Command{
 		&skipChecks,
 		&skipReportRendering,
 		&vmImpl,
+		&outputDirectory,
 	},
 }
 

--- a/driver/norma/run.go
+++ b/driver/norma/run.go
@@ -71,6 +71,12 @@ var (
 		Usage: "define a label for to be added to the monitoring data for this run. If empty, a random label is used.",
 		Value: "",
 	}
+	outputDirectory = cli.StringFlag{
+		Name:    "output-directory",
+		Usage:   "define a directory at which the monitoring artifact will be saved.",
+		Value:   "",
+		Aliases: []string{"o"},
+	}
 	keepPrometheusRunning = cli.BoolFlag{
 		Name:    "keep-prometheus-running",
 		Usage:   "if set, the Prometheus instance will not be shut down after the run is complete.",
@@ -138,10 +144,13 @@ func run(ctx *cli.Context) (err error) {
 	}
 
 	fmt.Printf("Starting evaluation %s\n", label)
-	outputDir, err := os.MkdirTemp("", fmt.Sprintf("norma_data_%s_", label))
+
+	// if not configured, default to /tmp/norma_data_<label>_<timestamp> else /configured/path/norma_data_<l>_<t>
+	outputDir, err := os.MkdirTemp(ctx.String(outputDirectory.Name), fmt.Sprintf("norma_data_%s_", label))
 	if err != nil {
-		return err
+		return fmt.Errorf("Couldn't create temp dir for output; %s", err)
 	}
+
 	fmt.Printf("Monitoring data is written to %v\n", outputDir)
 
 	// Copy scenario yml to outputDir as well to provide context

--- a/driver/norma/run.go
+++ b/driver/norma/run.go
@@ -66,7 +66,7 @@ var (
 	}
 	evalLabel = cli.StringFlag{
 		Name:  "label",
-		Usage: "define a label for to be added to the monitoring data for this run. I empty, a random label is used.",
+		Usage: "define a label for to be added to the monitoring data for this run. If empty, a random label is used.",
 		Value: "",
 	}
 	keepPrometheusRunning = cli.BoolFlag{
@@ -98,7 +98,7 @@ func run(ctx *cli.Context) (err error) {
 	if db == "carmen" || db == "go-file" {
 		db = "go-file"
 	} else if db != "geth" {
-		return fmt.Errorf("unknown value fore --%v flag: %v", dbImpl.Name, db)
+		return fmt.Errorf("unknown value for --%v flag: %v", dbImpl.Name, db)
 	}
 
 	vm := strings.ToLower(ctx.String(vmImpl.Name))
@@ -106,7 +106,7 @@ func run(ctx *cli.Context) (err error) {
 		vm = "lfvm"
 	}
 	if !isValidVmImpl(vm) {
-		return fmt.Errorf("unknown value fore --%v flag: %v", vmImpl.Name, vm)
+		return fmt.Errorf("unknown value for --%v flag: %v", vmImpl.Name, vm)
 	}
 
 	label := ctx.String(evalLabel.Name)


### PR DESCRIPTION
- Each scenario now has its own label (`A1.xxx.yml` now runs with flag `--label A1`)
- As an option, output directory after a run can be configured using the flag `--output-directory <path>` or `-o <path>`.
    - If unconfigured, defaults to `/tmp/` as before
    - Additionally, a symlink is created so that `/path/to/output/norma_data_<label>_latest)` always links to the latest run.
- Jenkins now archive the monitoring folder whenever the scenario run is successful