### PR TITLE
Gofmt now skip client directory

### DIFF
--- a/CI.jenkinsfile
+++ b/CI.jenkinsfile
@@ -33,7 +33,7 @@ pipeline {
 		stage('Check Norma Format') {
 			steps {
 				catchError(buildResult: 'UNSTABLE', stageResult: 'FAILURE') {
-					sh 'diff=`${GOROOT}/bin/gofmt -l .`; echo "$diff"; test -z "$diff"'
+					sh 'diff=`${GOROOT}/bin/gofmt -l . | grep -v "client"`; echo "$diff"; test -z "$diff"'
 				}
 			}
 		}


### PR DESCRIPTION
Currently, when reusing GCP VM, client submodule remains as causes gofmt check to fail.
This is a workaround to skip the directory for the time being.