### PR TITLE
Add double sign cheater

### DIFF
--- a/driver/executor/executor.go
+++ b/driver/executor/executor.go
@@ -196,6 +196,7 @@ func scheduleNodeEvents(node *parser.Node, queue *eventQueue, net driver.Network
 			newNode, err := net.CreateNode(&driver.NodeConfig{
 				Name:      name,
 				Validator: node.IsValidator(),
+				Cheater:   node.IsCheater(),
 			})
 			*instance = newNode
 			return err

--- a/driver/network.go
+++ b/driver/network.go
@@ -93,6 +93,7 @@ type NetworkListener interface {
 type NodeConfig struct {
 	Name      string
 	Validator bool
+	Cheater   bool
 	// TODO: add other parameters as needed
 	//  - features to include on the node
 	//  - state DB configuration

--- a/driver/network/local/local.go
+++ b/driver/network/local/local.go
@@ -190,6 +190,18 @@ func (n *LocalNetwork) CreateNode(config *driver.NodeConfig) (driver.Node, error
 		}
 	}
 
+	if config.Cheater {
+		_, err := n.createNode(&node.OperaNodeConfig{
+			Label:            "cheater-" + config.Name,
+			NetworkConfig:    &n.config,
+			VmImplementation: n.config.VmImplementation,
+			ValidatorId:      &newValId,
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	return n.createNode(&node.OperaNodeConfig{
 		Label:            config.Name,
 		NetworkConfig:    &n.config,

--- a/driver/parser/parser.go
+++ b/driver/parser/parser.go
@@ -67,6 +67,16 @@ func (n *Node) IsValidator() bool {
 	return false
 }
 
+// IsCheater returns true if the node is defined as cheater in Features
+func (n *Node) IsCheater() bool {
+	for _, item := range n.Features {
+		if item == "cheater" {
+			return true
+		}
+	}
+	return false
+}
+
 // Genesis is an optional configuration for a node.
 // GenesisImport will stop the client and restart the client with the target
 // genesis file at the provided time.

--- a/scenarios/small_new_cheater.yml
+++ b/scenarios/small_new_cheater.yml
@@ -1,0 +1,33 @@
+# This scenario simulates a small network, where 3 new validator that are added during small transaction load.
+
+# The name of the scenario
+name: Small Network new Validator
+
+# The duration of the scenario's runtime, in seconds.
+duration: 200
+
+# The number of validator nodes in the network.
+num_validators: 2
+
+genesis_gas_limit:
+  max_block_gas: 20500000
+  max_epoch_gas: 20500000
+
+# The network scenario to exercise.
+nodes:
+  - name: A
+    instances: 1
+    start: 15
+    features:
+      - validator
+      - cheater
+
+# In the network there is a single application producing constant load.
+applications:
+  - name: load
+    type: counter
+    start: 10          # start time
+    end: 180     # termination time
+    users: 20          # number of users using the app
+    rate:
+      constant: 10     # Tx/s

--- a/scenarios/small_new_cheater.yml
+++ b/scenarios/small_new_cheater.yml
@@ -1,14 +1,22 @@
-# This scenario simulates a small network, where 3 new validator that are added during small transaction load.
+# This scenario simulates a small network, where same validator key is added to two nodes simultaneously.
+# Three possible outcomes are possible occurring randomly:
+# 1. Cheater node 1 detects that Cheater node 2 signing event with their key and shuts down.
+#  Cheater node 2 continues running in network and network doesn't register any change.
+# 2. Both cheater nodes sign different event and recognize that another event was sign not by them, both of them panic.
+#  But network keeps running as there was no same event double signed.
+# 3. Both cheater nodes sign same event. And network should detect the validator key as a cheater.
+
 
 # The name of the scenario
 name: Small Network new Validator
 
 # The duration of the scenario's runtime, in seconds.
-duration: 200
+duration: 400
 
 # The number of validator nodes in the network.
-num_validators: 2
+num_validators: 3
 
+# Lower maximum gas limit to increase epoch rate.
 genesis_gas_limit:
   max_block_gas: 20500000
   max_epoch_gas: 20500000
@@ -17,7 +25,7 @@ genesis_gas_limit:
 nodes:
   - name: A
     instances: 1
-    start: 15
+    start: 10
     features:
       - validator
       - cheater
@@ -26,8 +34,12 @@ nodes:
 applications:
   - name: load
     type: counter
-    start: 10          # start time
-    end: 180     # termination time
+    start: 30          # start time
+    end: 380     # termination time
     users: 20          # number of users using the app
     rate:
-      constant: 10     # Tx/s
+      constant: 1     # Tx/s
+
+
+
+

--- a/scenarios/small_new_validator.yml
+++ b/scenarios/small_new_validator.yml
@@ -9,6 +9,7 @@ duration: 200
 # The number of validator nodes in the network.
 num_validators: 2
 
+# Lower maximum gas limit to increase epoch rate
 genesis_gas_limit:
   max_block_gas: 20500000
   max_epoch_gas: 20500000


### PR DESCRIPTION
Add option to start validator as cheater. This is reached by starting two nodes with same private key. 

TODO: timing of node start still needs to be dialed in and might never be 100% deterministic in causing the cheater.