### PR TITLE
Epoch is also logged via BlockHeight monitoring

### DIFF
--- a/driver/monitoring/node/block_progress.go
+++ b/driver/monitoring/node/block_progress.go
@@ -78,24 +78,15 @@ func (s *blockProgressSensor) ReadValue() (mon.BlockStatus, error) {
 		return mon.BlockStatus{}, err
 	}
 
-	epoch, err := fromHexToInt(raw["epoch"].(string))
+	epoch, err := strconv.ParseUint(raw["epoch"].(string), 0, 64)
 	if err != nil {
 		return mon.BlockStatus{}, err
 	}
 
-	number, err := fromHexToInt(raw["number"].(string))
+	number, err := strconv.ParseUint(raw["number"].(string), 0, 64)
 	if err != nil {
 		return mon.BlockStatus{}, err
 	}
 
 	return mon.BlockStatus{epoch, number}, nil
-}
-
-func fromHexToInt(hex string) (int, error) {
-	s := strings.TrimPrefix(hex, "0x")
-	i64, err := strconv.ParseInt(s, 16, 32)
-	if err != nil {
-		return 0, fmt.Errorf("failed to convert hex %s to int; %w", hex, err)
-	}
-	return int(i64), nil
 }

--- a/driver/monitoring/node/block_progress.go
+++ b/driver/monitoring/node/block_progress.go
@@ -30,35 +30,36 @@ import (
 	"github.com/ethereum/go-ethereum/rpc"
 )
 
-// NodeBlockHeight collects a per-node time series of its current block height.
-var NodeBlockHeight = mon.Metric[mon.Node, mon.Series[mon.Time, int]]{
-	Name:        "NodeBlockHeight",
-	Description: "The block height of nodes at various times.",
+// NodeBlockStatus collects a per-node time series of its current block height.
+var NodeBlockStatus = mon.Metric[mon.Node, mon.Series[mon.Time, mon.BlockStatus]]{
+	Name:        "NodeBlockStatus",
+	Description: "The epoch number and block height of nodes at various times.",
 }
 
 func init() {
-	if err := mon.RegisterSource(NodeBlockHeight, NewNodeBlockHeightSource); err != nil {
+	if err := mon.RegisterSource(NodeBlockStatus, NewNodeBlockStatusSource); err != nil {
 		panic(fmt.Sprintf("failed to register metric source: %v", err))
 	}
 }
 
-// NewNodeBlockHeightSource creates a new data source periodically collecting data on
+// NewNodeBlockStatusSource creates a new data source periodically collecting data on
 // the block height at various nodes over time.
-func NewNodeBlockHeightSource(monitor *mon.Monitor) mon.Source[mon.Node, mon.Series[mon.Time, int]] {
-	return newNodeBlockHeightSource(monitor, time.Second)
+func NewNodeBlockStatusSource(monitor *mon.Monitor) mon.Source[mon.Node, mon.Series[mon.Time, mon.BlockStatus]] {
+	return newNodeBlockStatusSource(monitor, time.Second)
 }
 
-func newNodeBlockHeightSource(monitor *mon.Monitor, period time.Duration) mon.Source[mon.Node, mon.Series[mon.Time, int]] {
-	return newPeriodicNodeDataSource[int](NodeBlockHeight, monitor, period, &blockProgressSensorFactory{})
+func newNodeBlockStatusSource(monitor *mon.Monitor, period time.Duration) mon.Source[mon.Node, mon.Series[mon.Time, mon.BlockStatus]] {
+	return newPeriodicNodeDataSource[mon.BlockStatus](NodeBlockStatus, monitor, period, &blockProgressSensorFactory{})
 }
 
 type blockProgressSensorFactory struct{}
 
-func (f *blockProgressSensorFactory) CreateSensor(node driver.Node) (utils.Sensor[int], error) {
+func (f *blockProgressSensorFactory) CreateSensor(node driver.Node) (utils.Sensor[mon.BlockStatus], error) {
 	url := node.GetServiceUrl(&opera.OperaRpcService)
 	if url == nil {
 		return nil, fmt.Errorf("node does not export an RPC server")
 	}
+	// current version of eth in sonic doesn't allow access to inner client
 	rpcClient, err := rpc.DialContext(context.Background(), string(*url))
 	if err != nil {
 		return nil, err
@@ -70,16 +71,31 @@ type blockProgressSensor struct {
 	rpcClient *rpc.Client
 }
 
-func (s *blockProgressSensor) ReadValue() (int, error) {
-	var blockNumber string
-	err := s.rpcClient.Call(&blockNumber, "eth_blockNumber")
+func (s *blockProgressSensor) ReadValue() (mon.BlockStatus, error) {
+	var raw map[string]interface{}
+	err := s.rpcClient.Call(&raw, "eth_getBlockByNumber", "latest", false)
 	if err != nil {
-		return 0, err
+		return mon.BlockStatus{}, err
 	}
-	blockNumber = strings.TrimPrefix(blockNumber, "0x")
-	value, err := strconv.ParseInt(blockNumber, 16, 32)
+
+	epoch, err := fromHexToInt(raw["epoch"].(string))
 	if err != nil {
-		return 0, err
+		return mon.BlockStatus{}, err
 	}
-	return int(value), nil
+
+	number, err := fromHexToInt(raw["number"].(string))
+	if err != nil {
+		return mon.BlockStatus{}, err
+	}
+
+	return mon.BlockStatus{epoch, number}, nil
+}
+
+func fromHexToInt(hex string) (int, error) {
+	s := strings.TrimPrefix(hex, "0x")
+	i64, err := strconv.ParseInt(s, 16, 32)
+	if err != nil {
+		return 0, fmt.Errorf("failed to convert hex %s to int; %w", hex, err)
+	}
+	return int(i64), nil
 }

--- a/driver/monitoring/node/block_progress.go
+++ b/driver/monitoring/node/block_progress.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/Fantom-foundation/Norma/driver"
@@ -88,5 +87,5 @@ func (s *blockProgressSensor) ReadValue() (mon.BlockStatus, error) {
 		return mon.BlockStatus{}, err
 	}
 
-	return mon.BlockStatus{epoch, number}, nil
+	return mon.BlockStatus{int(epoch), int(number)}, nil
 }

--- a/driver/monitoring/node/block_progress.go
+++ b/driver/monitoring/node/block_progress.go
@@ -87,5 +87,5 @@ func (s *blockProgressSensor) ReadValue() (mon.BlockStatus, error) {
 		return mon.BlockStatus{}, err
 	}
 
-	return mon.BlockStatus{int(epoch), int(number)}, nil
+	return mon.BlockStatus{epoch, number}, nil
 }

--- a/driver/monitoring/node/block_progress_test.go
+++ b/driver/monitoring/node/block_progress_test.go
@@ -142,9 +142,10 @@ func TestLocalRpcServer_CanHandleRequests(t *testing.T) {
 		t.Fatalf("failed to call service: %v", err)
 	}
 
-	if result["number"] != "0x12" {
+	if result["number"] != "0x12" || result["epoch"] != "0x34" {
 		t.Errorf("invalid response: %v", result)
 	}
+
 	server.Shutdown()
 }
 

--- a/driver/monitoring/node/block_progress_test.go
+++ b/driver/monitoring/node/block_progress_test.go
@@ -118,7 +118,7 @@ func TestNodeBlockHeightSourceRetrievesBlockHeight(t *testing.T) {
 			t.Errorf("no data collected for node %s", subject)
 		}
 		for _, point := range subrange {
-			if got, want := point.Value.BlockHeight, 0x12; got != want {
+			if got, want := point.Value.BlockHeight, uint64(0x12); got != want {
 				t.Errorf("unexpected value collected for subject %s: wanted %d, got %d", subject, want, got)
 			}
 		}

--- a/driver/monitoring/node/block_progress_test.go
+++ b/driver/monitoring/node/block_progress_test.go
@@ -74,7 +74,7 @@ func TestNodeBlockHeightSourceRetrievesBlockHeight(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to initiate monitor: %v", err)
 	}
-	source := newNodeBlockHeightSource(monitor, 50*time.Millisecond)
+	source := newNodeBlockStatusSource(monitor, 50*time.Millisecond)
 
 	// Check that existing nodes are tracked.
 	subjects := source.GetSubjects()
@@ -118,7 +118,7 @@ func TestNodeBlockHeightSourceRetrievesBlockHeight(t *testing.T) {
 			t.Errorf("no data collected for node %s", subject)
 		}
 		for _, point := range subrange {
-			if got, want := point.Value, 0x12; got != want {
+			if got, want := point.Value.BlockHeight, 0x12; got != want {
 				t.Errorf("unexpected value collected for subject %s: wanted %d, got %d", subject, want, got)
 			}
 		}

--- a/driver/monitoring/node/block_progress_test.go
+++ b/driver/monitoring/node/block_progress_test.go
@@ -136,13 +136,13 @@ func TestLocalRpcServer_CanHandleRequests(t *testing.T) {
 		t.Fatalf("failed to connect to server: %v", err)
 	}
 
-	var result string
+	var result map[string]any
 	err = rpcClient.Call(&result, "eth_blockNumber")
 	if err != nil {
 		t.Fatalf("failed to call service: %v", err)
 	}
 
-	if result != "0x12" {
+	if result["number"] != "0x12" {
 		t.Errorf("invalid response: %v", result)
 	}
 	server.Shutdown()
@@ -198,7 +198,10 @@ func getBlockHeight(w http.ResponseWriter, r *http.Request) {
 	response := `{
 		"jsonrpc": "2.0",
 		"id": "1234",
-		"result": "0x12"
+		"result": {
+			"epoch": "0x34",
+			"number": "0x12"
+		}
 	}`
 	io.WriteString(w, response)
 }

--- a/driver/monitoring/record.go
+++ b/driver/monitoring/record.go
@@ -83,6 +83,8 @@ func (r *Record) SetValue(value any) *Record {
 		r.Value = fmt.Sprintf("%d", v.UTC().UnixNano())
 	case time.Duration:
 		r.Value = fmt.Sprintf("%d", v.Nanoseconds())
+	case BlockStatus:
+		r.Value = fmt.Sprintf("%d", v.BlockHeight)
 	default:
 		panic(fmt.Sprintf("unsupported value encountered: %v (type: %v)", value, reflect.TypeOf(value)))
 	}

--- a/driver/monitoring/types.go
+++ b/driver/monitoring/types.go
@@ -62,6 +62,16 @@ func (t Time) String() string {
 // BlockNumber is the type used to identify a block.
 type BlockNumber int
 
+// BlockStatus encapsulates epoch, blockheight
+type BlockStatus struct {
+	Epoch       int
+	BlockHeight int
+}
+
+func (b BlockStatus) String() string {
+	return fmt.Sprintf("%d/%d", b.Epoch, b.BlockHeight)
+}
+
 // Percent is used to represent a percentage of some value. Internaly it is
 // represented as a float value, typically in the range between [0,1] denoting
 // values between 0% and 100%. However, values exceeding those boundaries are

--- a/driver/monitoring/types.go
+++ b/driver/monitoring/types.go
@@ -64,8 +64,8 @@ type BlockNumber int
 
 // BlockStatus encapsulates epoch, blockheight
 type BlockStatus struct {
-	Epoch       int
-	BlockHeight int
+	Epoch       uint64
+	BlockHeight uint64
 }
 
 func (b BlockStatus) String() string {

--- a/driver/norma/run.go
+++ b/driver/norma/run.go
@@ -308,12 +308,13 @@ func (l *progressLogger) shutdown() {
 
 func logState(monitor *monitoring.Monitor) {
 	numNodes := getNumNodes(monitor)
-	blockHeights := getBlockHeights(monitor)
+	blockStatuses := getBlockStatuses(monitor)
 	txPers := getTxPerSec(monitor)
 	txs := getNumTxs(monitor)
 	gas := getGasUsed(monitor)
 	processingTimes := getBlockProcessingTimes(monitor)
-	log.Printf("Nodes: %s, block heights: %v, tx/s: %v, txs: %v, gas: %s, block processing: %v", numNodes, blockHeights, txPers, txs, gas, processingTimes)
+
+	log.Printf("Nodes: %s, block heights: %v, tx/s: %v, txs: %v, gas: %s, block processing: %v", numNodes, blockStatuses, txPers, txs, gas, processingTimes)
 }
 
 func getNumNodes(monitor *monitoring.Monitor) string {
@@ -336,9 +337,9 @@ func getGasUsed(monitor *monitoring.Monitor) string {
 	return getLastValAsString[monitoring.BlockNumber, int](exists, data)
 }
 
-func getBlockHeights(monitor *monitoring.Monitor) []string {
-	metric := nodemon.NodeBlockHeight
-	return getLastValAllSubjects[monitoring.Time, int, monitoring.Series[monitoring.Time, int]](monitor, metric)
+func getBlockStatuses(monitor *monitoring.Monitor) []string {
+	metric := nodemon.NodeBlockStatus
+	return getLastValAllSubjects[monitoring.Time, monitoring.BlockStatus, monitoring.Series[monitoring.Time, monitoring.BlockStatus]](monitor, metric)
 }
 
 func getBlockProcessingTimes(monitor *monitoring.Monitor) []string {


### PR DESCRIPTION
BlockHeight monitoring now tracks Epoch in addition to BlockHeight (and thus renamed BlockStatus).
`[B B B]` now reads `[E/B E/B E/B]` where B = Block Height and E = Epoch Number

Example of log:
```2024/08/07 10:45:05 Nodes: 3, block heights: [2/1 2/1 2/1], tx/s: [], txs: N/A, gas: N/A, block processing: []```

