### PR TITLE
Collapse upload artifacts

### DIFF
--- a/RT.jenkinsfile
+++ b/RT.jenkinsfile
@@ -106,9 +106,7 @@ pipeline {
 
 			post {
 				always {
-					script {
-						uploadArtifacts(["*.yml", "*.csv", "*.log", "*.html"])
-					}
+					uploadArtifacts(["*.yml", "*.csv", "*.log", "*.html"])
 				}
 			}
 

--- a/RT.jenkinsfile
+++ b/RT.jenkinsfile
@@ -87,9 +87,7 @@ pipeline {
 
 			post {
 				always {
-					script {
-						uploadArtifacts(["*.yml", "*.csv", "*.log", "*.html"])
-					}
+					uploadArtifacts(["*.yml", "*.csv", "*.log", "*.html"])
 				}
 			}
 		}

--- a/RT.jenkinsfile
+++ b/RT.jenkinsfile
@@ -86,9 +86,9 @@ pipeline {
 			}
 
 			post {
-				success {
-					dir('./norma_data_a1_latest') {
-						archiveArtifacts artifacts: '**'
+				always {
+					script {
+						uploadArtifacts(["*.yml", "*.csv", "*.log", "*.html"])
 					}
 				}
 			}
@@ -107,9 +107,9 @@ pipeline {
 			}
 
 			post {
-				success {
-					dir('./norma_data_a2_latest') {
-						archiveArtifacts artifacts: '**'
+				always {
+					script {
+						uploadArtifacts(["*.yml", "*.csv", "*.log", "*.html"])
 					}
 				}
 			}
@@ -131,8 +131,7 @@ pipeline {
 			post {
 				always {
 					script {
-						def artifacts = ["*.yml", "*.csv", "*.log", "*.html"]
-						uploadArtifacts(artifacts)
+						uploadArtifacts(["*.yml", "*.csv", "*.log", "*.html"])
 					}
 				}
 			}
@@ -153,8 +152,7 @@ pipeline {
 			post {
 				always {
 					script {
-						def artifacts = ["*.yml", "*.csv", "*.log", "*.html"]
-						uploadArtifacts(artifacts)
+						uploadArtifacts(["*.yml", "*.csv", "*.log", "*.html"])
 					}
 				}
 			}
@@ -175,8 +173,7 @@ pipeline {
 			post {
 				always {
 					script {
-						def artifacts = ["*.yml", "*.csv", "*.log", "*.html"]
-						uploadArtifacts(artifacts)
+						uploadArtifacts(["*.yml", "*.csv", "*.log", "*.html"])
 					}
 				}
 			}
@@ -195,9 +192,9 @@ pipeline {
 			}
 
 			post {
-				success {
-					dir('./norma_data_b4_latest') {
-						archiveArtifacts artifacts: '**'
+				always {
+					script {
+						uploadArtifacts(["*.yml", "*.csv", "*.log", "*.html"])
 					}
 				}
 			}
@@ -218,8 +215,7 @@ pipeline {
 			post {
 				always {
 					script {
-						def artifacts = ["*.yml", "*.csv", "*.log", "*.html"]
-						uploadArtifacts(artifacts)
+						uploadArtifacts(["*.yml", "*.csv", "*.log", "*.html"])
 					}
 				}
 			}
@@ -238,13 +234,12 @@ pipeline {
 			}
 
 			post {
-				success {
-					dir('./norma_data_c1_latest') {
-						archiveArtifacts artifacts: '**'
+				always {
+					script {
+						uploadArtifacts(["*.yml", "*.csv", "*.log", "*.html"])
 					}
 				}
 			}
-
 		}
 	}
 }


### PR DESCRIPTION
```
        post {
		always {
			script {
				def artifacts = ["*.yml", "*.csv", "*.log", "*.html"]
				uploadArtifacts(artifacts)
			}
		}
	}
```

should now reads:
```
	post {
		always {
			uploadArtifacts(["*.yml", "*.csv", "*.log", "*.html"])
		}
	}
```