### PR TITLE
[Hotfix] Event export scenarios now kept at minimum 2 validators

### DIFF
--- a/driver/executor/executor.go
+++ b/driver/executor/executor.go
@@ -397,7 +397,7 @@ func scheduleNodeEvents(node *parser.Node, queue *eventQueue, net driver.Network
 					}
 
 					fmt.Printf("[%s] Exporting events from %s to %s\n", name, datadir, path)
-					err = chain.ExportEvents(writer, nodeMount, idx.Epoch(1), idx.Epoch(0))
+					err = chain.ExportEvents(writer, nodeMount, idx.Epoch(1), idx.Epoch(20))
 					if err != nil {
 						return nil, fmt.Errorf("export events error: %w\n", err)
 					}

--- a/scenarios/export_events_30s.yml
+++ b/scenarios/export_events_30s.yml
@@ -1,5 +1,5 @@
 name: Event Export Simulation
-duration: 20 # 20s simulation time
+duration: 30 # 30s simulation time
 genesis_gas_limit: 
   max_block_gas: 38750000
   max_epoch_gas: 187500000
@@ -8,6 +8,7 @@ genesis_gas_limit:
 # Total amount of nodes in this scenarios = 5 (1 validators + 1 observer +2 = 4)
 nodes: 
   - name: validator
+    instances: 2
     client:
       type: validator   
     mount: tmp
@@ -20,7 +21,7 @@ applications:
     instances: 2
     type: ERC20
     start: 1          
-    end: 19
+    end: 29
     users: 10
     rate:
       constant: 200   # Tx/s

--- a/scenarios/export_events_5m.yml
+++ b/scenarios/export_events_5m.yml
@@ -12,8 +12,8 @@ nodes:
     client:
       type: validator   
     mount: tmp
-      #event:
-      #export: events.gz
+    event:
+      export: events.gz
   - name: observer
 
 applications:

--- a/scenarios/export_events_5m.yml
+++ b/scenarios/export_events_5m.yml
@@ -8,11 +8,12 @@ genesis_gas_limit:
 # Total amount of nodes in this scenarios = 5 (1 validators + 1 observer +2 = 4)
 nodes: 
   - name: validator
+    instances: 2
     client:
       type: validator   
     mount: tmp
-    event:
-      export: events.gz
+      #event:
+      #export: events.gz
   - name: observer
 
 applications:


### PR DESCRIPTION
Currently event exporting scenarios now have 1 validator each. We found that the validation is stuck at epoch 3 height 9 across the network. This does not happen when we have at least 2 validators, so the scenarios are modified as such.