### PR TITLE
[Hotfix] Event export scenarios now kept at minimum 2 validators 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,14 +40,18 @@ ENV STATE_DB_IMPL="geth"
 ENV VM_IMPL="geth"
 ENV LD_LIBRARY_PATH=./
 
-EXPOSE 5050
-EXPOSE 6060
-EXPOSE 18545
-EXPOSE 18546
+EXPOSE 5050 6060 18545 18546
 
 COPY genesis/example-genesis.json ./genesis.json
 COPY scripts/run_sonic_privatenet.sh ./run_sonic.sh
 COPY scripts/set_genesis.sh ./set_genesis.sh
 COPY build/normatool ./normatool
 
-CMD ["/bin/bash", "run_sonic.sh"]
+# Add https://github.com/krallin/tini
+ENV TINI_VERSION=v0.19.0
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
+RUN chmod +x /tini
+
+# -g forwards SIGINT to child processes and terminates client gracefully
+ENTRYPOINT ["/tini", "-g", "--"]
+CMD ["/bin/bash", "/run_sonic.sh"]

--- a/driver/docker/docker.go
+++ b/driver/docker/docker.go
@@ -78,7 +78,8 @@ type ContainerConfig struct {
 	Environment     map[string]string
 	Entrypoint      []string // Entrypoint to run when starting the container. Optional.
 	Network         *Network // Docker network to join, nil to join bridge network
-	Mount           *string  // mount client datadir to this path on host
+	MountDatadir    *string  // mount client datadir to this path on host
+	MountGenesis    *string  // mount client genesis to this path on host
 }
 
 // NewClient creates a new client facilitating the creation of Docker
@@ -155,11 +156,18 @@ func (c *Client) Start(config *ContainerConfig) (*Container, error) {
 	}
 
 	mountConfig := []mount.Mount{}
-	if config.Mount != nil {
+	if config.MountDatadir != nil {
 		mountConfig = append(mountConfig, mount.Mount{
 			Type:   mount.TypeBind,
-			Source: *config.Mount,
+			Source: *config.MountDatadir,
 			Target: "/datadir",
+		})
+	}
+	if config.MountGenesis != nil {
+		mountConfig = append(mountConfig, mount.Mount{
+			Type:   mount.TypeBind,
+			Source: *config.MountGenesis,
+			Target: "/genesis",
 		})
 	}
 

--- a/driver/docker/docker.go
+++ b/driver/docker/docker.go
@@ -41,6 +41,7 @@ const objectsLabel = "norma"
 type Signal string
 
 // SigHup is the SIGHUP signal.
+var SigInt Signal = "SIGINT"
 var SigHup Signal = "SIGHUP"
 var SigKill Signal = "SIGKILL"
 

--- a/driver/executor/executor.go
+++ b/driver/executor/executor.go
@@ -421,13 +421,9 @@ func scheduleNodeEvents(node *parser.Node, queue *eventQueue, net driver.Network
 						return nil, fmt.Errorf("failed to export events; epochTracker == nil")
 					}
 
-					if id == nil {
-						return nil, fmt.Errorf("failed to export events; id == nil")
-					}
-
 					ep, exists := epochTracker[monitoring.Node(name)]
 					if !exists {
-						return nil, fmt.Errorf("failed to export events; failed to track %d in epochTracker %v\n", name, epochTracker)
+						return nil, fmt.Errorf("failed to export events; failed to track %s in epochTracker %v\n", name, epochTracker)
 					}
 
 					epoch, err := strconv.ParseInt(ep, 10, 32)

--- a/driver/executor/executor.go
+++ b/driver/executor/executor.go
@@ -24,10 +24,12 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/Fantom-foundation/Norma/driver"
+	"github.com/Fantom-foundation/Norma/driver/monitoring"
 	"github.com/Fantom-foundation/Norma/driver/parser"
 	"github.com/Fantom-foundation/go-opera/cmd/sonictool/chain"
 	"github.com/Fantom-foundation/lachesis-base/inter/idx"
@@ -37,7 +39,7 @@ import (
 // Run executes the given scenario on the given network using the provided clock
 // as a time source. Execution will fail (fast) if the scenario is not valid (see
 // Scenario's Check() function).
-func Run(clock Clock, network driver.Network, scenario *parser.Scenario, outputDir string) error {
+func Run(clock Clock, network driver.Network, scenario *parser.Scenario, outputDir string, epochTracker map[monitoring.Node]string) error {
 	if err := scenario.Check(); err != nil {
 		return err
 	}
@@ -52,7 +54,7 @@ func Run(clock Clock, network driver.Network, scenario *parser.Scenario, outputD
 
 	// Schedule all operations listed in the scenario.
 	for _, node := range scenario.Nodes {
-		scheduleNodeEvents(&node, queue, network, endTime, outputDir)
+		scheduleNodeEvents(&node, queue, network, endTime, outputDir, epochTracker)
 	}
 	for _, app := range scenario.Applications {
 		if err := scheduleApplicationEvents(&app, queue, network, endTime); err != nil {
@@ -183,7 +185,7 @@ func toSingleEvent(time Time, name string, action func() error) event {
 // nodes during the scenario execution. The nature of the scheduled nodes is taken from the
 // given node description, and actions are applied to the given network.
 // Node Lifecycle: create -> timer sim events {start, end, kill, restart} -> remove
-func scheduleNodeEvents(node *parser.Node, queue *eventQueue, net driver.Network, end Time, outputDir string) {
+func scheduleNodeEvents(node *parser.Node, queue *eventQueue, net driver.Network, end Time, outputDir string, epochTracker map[monitoring.Node]string) {
 	instances := 1
 	if node.Instances != nil {
 		instances = *node.Instances
@@ -415,10 +417,28 @@ func scheduleNodeEvents(node *parser.Node, queue *eventQueue, net driver.Network
 						defer writer.(*gzip.Writer).Close()
 					}
 
-					fmt.Printf("[%s] Exporting events from %s to %s\n", name, pathToDatadir, pathToOutput)
-					err = chain.ExportEvents(writer, pathToDatadir, idx.Epoch(1), idx.Epoch(20))
+					if epochTracker == nil {
+						return nil, fmt.Errorf("failed to export events; epochTracker == nil")
+					}
+
+					if id == nil {
+						return nil, fmt.Errorf("failed to export events; id == nil")
+					}
+
+					ep, exists := epochTracker[monitoring.Node(name)]
+					if !exists {
+						return nil, fmt.Errorf("failed to export events; failed to track %d in epochTracker %v\n", name, epochTracker)
+					}
+
+					epoch, err := strconv.ParseInt(ep, 10, 32)
 					if err != nil {
-						return nil, fmt.Errorf("export events error: %w\n", err)
+						return nil, fmt.Errorf("failed to export events; failed to convert epoch to int; %w\n", err)
+					}
+
+					fmt.Printf("[%s] Exporting events up to epoch %d to path %s\n", name, epoch, path)
+					err = chain.ExportEvents(writer, nodeMount, idx.Epoch(1), idx.Epoch(epoch))
+					if err != nil {
+						return nil, fmt.Errorf("failed to export events; %w\n", err)
 					}
 				}
 				return []event{exportFinalGenesis}, nil

--- a/driver/executor/executor.go
+++ b/driver/executor/executor.go
@@ -198,6 +198,11 @@ func scheduleNodeEvents(node *parser.Node, queue *eventQueue, net driver.Network
 	if node.End != nil {
 		endTime = Seconds(*node.End)
 	}
+	nodeIsValidator := false
+	if node.Client.Type == "validator" {
+		nodeIsValidator = true
+	}
+	nodeIsCheater := false
 	nodeImportEvent := ""
 	if node.Event.Import != nil {
 		nodeImportEvent = *node.Event.Import
@@ -289,13 +294,13 @@ func scheduleNodeEvents(node *parser.Node, queue *eventQueue, net driver.Network
 
 				newNode, err := net.CreateNode(&driver.NodeConfig{
 					Name:         name,
-					Validator:    node.IsValidator(),
-					Cheater:      node.IsCheater(),
+					Validator:    nodeIsValidator,
+					Cheater:      nodeIsCheater,
 					MountDatadir: mountGenesis,
 					MountGenesis: mountDatadir,
 				})
-
 				*instance = newNode
+
 				return []event{importGenesis}, err
 			},
 		)

--- a/driver/executor/executor.go
+++ b/driver/executor/executor.go
@@ -416,7 +416,7 @@ func scheduleNodeEvents(node *parser.Node, queue *eventQueue, net driver.Network
 					}
 
 					fmt.Printf("[%s] Exporting events from %s to %s\n", name, pathToDatadir, pathToOutput)
-					err = chain.ExportEvents(writer, pathToDatadir, idx.Epoch(1), idx.Epoch(0))
+					err = chain.ExportEvents(writer, pathToDatadir, idx.Epoch(1), idx.Epoch(20))
 					if err != nil {
 						return nil, fmt.Errorf("export events error: %w\n", err)
 					}

--- a/driver/executor/executor.go
+++ b/driver/executor/executor.go
@@ -431,7 +431,7 @@ func scheduleNodeEvents(node *parser.Node, queue *eventQueue, net driver.Network
 						return nil, fmt.Errorf("failed to export events; failed to convert epoch to int; %w\n", err)
 					}
 
-					fmt.Printf("[%s] Exporting events up to epoch %d to path %s\n", name, epoch, path)
+					fmt.Printf("[%s] Exporting events up to epoch %d to path %s\n", name, epoch, pathToOutput)
 					err = chain.ExportEvents(writer, nodeMount, idx.Epoch(1), idx.Epoch(epoch))
 					if err != nil {
 						return nil, fmt.Errorf("failed to export events; %w\n", err)

--- a/driver/executor/executor_test.go
+++ b/driver/executor/executor_test.go
@@ -36,7 +36,7 @@ func TestExecutor_RunEmptyScenario(t *testing.T) {
 		Duration: 10,
 	}
 
-	if err := Run(clock, net, &scenario, ""); err != nil {
+	if err := Run(clock, net, &scenario, "", nil); err != nil {
 		t.Errorf("failed to run empty scenario: %v", err)
 	}
 	want := Seconds(10)
@@ -70,7 +70,7 @@ func TestExecutor_RunSingleNodeScenario(t *testing.T) {
 		node.EXPECT().Cleanup(),
 	)
 
-	if err := Run(clock, net, &scenario, ""); err != nil {
+	if err := Run(clock, net, &scenario, "", nil); err != nil {
 		t.Errorf("failed to run scenario: %v", err)
 	}
 	want := Seconds(10)
@@ -112,7 +112,7 @@ func TestExecutor_RunMultipleNodeScenario(t *testing.T) {
 		node2.EXPECT().Cleanup(),
 	)
 
-	if err := Run(clock, net, &scenario, ""); err != nil {
+	if err := Run(clock, net, &scenario, "", nil); err != nil {
 		t.Errorf("failed to run scenario: %v", err)
 	}
 	want := Seconds(10)
@@ -145,7 +145,7 @@ func TestExecutor_RunSingleApplicationScenario(t *testing.T) {
 	app.EXPECT().Start()
 	app.EXPECT().Stop()
 
-	if err := Run(clock, net, &scenario, ""); err != nil {
+	if err := Run(clock, net, &scenario, "", nil); err != nil {
 		t.Errorf("failed to run scenario: %v", err)
 	}
 	want := Seconds(10)
@@ -183,7 +183,7 @@ func TestExecutor_RunMultipleApplicationScenario(t *testing.T) {
 	app2.EXPECT().Start()
 	app2.EXPECT().Stop()
 
-	if err := Run(clock, net, &scenario, ""); err != nil {
+	if err := Run(clock, net, &scenario, "", nil); err != nil {
 		t.Errorf("failed to run scenario: %v", err)
 	}
 	want := Seconds(10)
@@ -215,7 +215,7 @@ func TestExecutor_TestUserAbort(t *testing.T) {
 		syscall.Kill(syscall.Getpid(), syscall.SIGINT)
 	}).Return(node, nil)
 
-	if err := Run(clock, net, &scenario, ""); err == nil {
+	if err := Run(clock, net, &scenario, "", nil); err == nil {
 		t.Errorf("a user interrupt error should be reported")
 	}
 	want := Seconds(1)

--- a/driver/monitoring/monitor_test.go
+++ b/driver/monitoring/monitor_test.go
@@ -169,7 +169,7 @@ func TestMonitorIntegrationPrometheusLogReceived(t *testing.T) {
 	})
 	node, err := opera.StartOperaDockerNode(client, nil, &opera.OperaNodeConfig{
 		Label:         "test",
-		NetworkConfig: &driver.NetworkConfig{NumberOfValidators: 1},
+		NetworkConfig: &driver.NetworkConfig{MandatoryNumberOfValidators: 1},
 	})
 	if err != nil {
 		t.Fatalf("failed to create an Opera node on Docker: %v", err)

--- a/driver/monitoring/node/cpu_profile_test.go
+++ b/driver/monitoring/node/cpu_profile_test.go
@@ -35,7 +35,7 @@ func TestCanCollectCpuProfileDateFromOperaNode(t *testing.T) {
 	})
 	node, err := opera.StartOperaDockerNode(docker, nil, &opera.OperaNodeConfig{
 		Label:         "test",
-		NetworkConfig: &driver.NetworkConfig{NumberOfValidators: 1},
+		NetworkConfig: &driver.NetworkConfig{MandatoryNumberOfValidators: 1},
 	})
 	if err != nil {
 		t.Fatalf("failed to create an Opera node on Docker: %v", err)

--- a/driver/monitoring/node/prom_log_source_test.go
+++ b/driver/monitoring/node/prom_log_source_test.go
@@ -100,7 +100,7 @@ func TestLogsIntegrationGetRealMetric(t *testing.T) {
 	})
 	node, err := opera.StartOperaDockerNode(client, nil, &opera.OperaNodeConfig{
 		Label:         "test",
-		NetworkConfig: &driver.NetworkConfig{NumberOfValidators: 1},
+		NetworkConfig: &driver.NetworkConfig{MandatoryNumberOfValidators: 1},
 	})
 	if err != nil {
 		t.Fatalf("failed to create an Opera node on Docker: %v", err)

--- a/driver/monitoring/prometheus/prometheus_test.go
+++ b/driver/monitoring/prometheus/prometheus_test.go
@@ -121,7 +121,7 @@ func startPrometheus(t *testing.T, net *local.LocalNetwork) *Prometheus {
 
 // createLocalNetwork creates a docker network and returns it.
 func createLocalNetwork(t *testing.T) *local.LocalNetwork {
-	config := driver.NetworkConfig{NumberOfValidators: 1}
+	config := driver.NetworkConfig{MandatoryNumberOfValidators: 1}
 	net, err := local.NewLocalNetwork(&config)
 	if err != nil {
 		t.Fatalf("error: %v", err)

--- a/driver/network.go
+++ b/driver/network.go
@@ -73,8 +73,10 @@ type Network interface {
 // NetworkConfig is a collection of network parameters to be used by factories
 // creating network instances.
 type NetworkConfig struct {
-	// NumberOfValidators is the (static) number of validators in the network.
-	NumberOfValidators int
+	// TotalNumberOfValidators is the total number of validators that appear in the scenario, including the additional mandatory ones.
+	TotalNumberOfValidators int
+	// NumberOfMandatoryValidators is minimum number of validators required for the network to function.
+	MandatoryNumberOfValidators int
 	// MaxBlockGas is the maximum gas limit for a block in the network.
 	MaxBlockGas uint64
 	// MaxEpochGas is the maximum gas limit for an epoch in the network.

--- a/driver/network.go
+++ b/driver/network.go
@@ -97,10 +97,11 @@ type NetworkListener interface {
 }
 
 type NodeConfig struct {
-	Name      string
-	Validator bool
-	Cheater   bool
-	Mount     *string // mount node datadir to string if not nil
+	Name         string
+	Validator    bool
+	Cheater      bool
+	MountDatadir *string // mount node datadir to path if not nil
+	MountGenesis *string // mount node genesis files to path if not nil
 	// TODO: add other parameters as needed
 	//  - features to include on the node
 	//  - state DB configuration

--- a/driver/network/local/local.go
+++ b/driver/network/local/local.go
@@ -127,7 +127,7 @@ func NewLocalNetwork(config *driver.NetworkConfig) (*LocalNetwork, error) {
 			nodeConfig := node.OperaNodeConfig{
 				ValidatorId:      &validatorId,
 				NetworkConfig:    config,
-				Label:            fmt.Sprintf("_validator-%d", validatorId),
+				Label:            fmt.Sprintf("_validator-%d", i),
 				VmImplementation: config.VmImplementation,
 			}
 			net.validators[i], errs[i] = net.createNode(&nodeConfig)

--- a/driver/network/local/local.go
+++ b/driver/network/local/local.go
@@ -205,6 +205,8 @@ func (n *LocalNetwork) CreateNode(config *driver.NodeConfig) (driver.Node, error
 	if config.Cheater {
 		_, err := n.createNode(&node.OperaNodeConfig{
 			Label:            "cheater-" + config.Name,
+			MountDatadir:     config.MountDatadir,
+			MountGenesis:     config.MountGenesis,
 			NetworkConfig:    &n.config,
 			VmImplementation: n.config.VmImplementation,
 			ValidatorId:      &newValId,
@@ -216,7 +218,8 @@ func (n *LocalNetwork) CreateNode(config *driver.NodeConfig) (driver.Node, error
 
 	return n.createNode(&node.OperaNodeConfig{
 		Label:            config.Name,
-		Mount:            config.Mount,
+		MountDatadir:     config.MountDatadir,
+		MountGenesis:     config.MountGenesis,
 		NetworkConfig:    &n.config,
 		VmImplementation: n.config.VmImplementation,
 		ValidatorId:      &newValId,

--- a/driver/network/local/local.go
+++ b/driver/network/local/local.go
@@ -116,13 +116,12 @@ func NewLocalNetwork(config *driver.NetworkConfig) (*LocalNetwork, error) {
 	net.RegisterListener(net.rpcWorkerPool)
 
 	// Start all validators.
-	net.validators = make([]*node.OperaNode, config.NumberOfValidators)
-	errs := make([]error, config.NumberOfValidators)
+	net.validators = make([]*node.OperaNode, config.MandatoryNumberOfValidators)
+	errs := make([]error, config.MandatoryNumberOfValidators)
 	var wg sync.WaitGroup
-	for i := 0; i < config.NumberOfValidators; i++ {
+	for i := 0; i < config.MandatoryNumberOfValidators; i++ {
 		wg.Add(1)
-		i := i
-		go func() {
+		go func(i int) {
 			defer wg.Done()
 			validatorId := i + 1
 			nodeConfig := node.OperaNodeConfig{
@@ -132,7 +131,7 @@ func NewLocalNetwork(config *driver.NetworkConfig) (*LocalNetwork, error) {
 				VmImplementation: config.VmImplementation,
 			}
 			net.validators[i], errs[i] = net.createNode(&nodeConfig)
-		}()
+		}(i)
 	}
 	wg.Wait()
 

--- a/driver/network/local/local_test.go
+++ b/driver/network/local/local_test.go
@@ -31,7 +31,7 @@ func TestLocalNetworkIsNetwork(t *testing.T) {
 
 func TestLocalNetwork_CanStartNodesAndShutThemDown(t *testing.T) {
 	t.Parallel()
-	config := driver.NetworkConfig{NumberOfValidators: 1}
+	config := driver.NetworkConfig{MandatoryNumberOfValidators: 1}
 	for _, N := range []int{1, 3} {
 		N := N
 		t.Run(fmt.Sprintf("num_nodes=%d", N), func(t *testing.T) {
@@ -73,7 +73,7 @@ func TestLocalNetwork_CanStartNodesAndShutThemDown(t *testing.T) {
 
 func TestLocalNetwork_CanStartApplicatonsAndShutThemDown(t *testing.T) {
 	t.Parallel()
-	config := driver.NetworkConfig{NumberOfValidators: 1}
+	config := driver.NetworkConfig{MandatoryNumberOfValidators: 1}
 	for _, N := range []int{1, 3} {
 		N := N
 		t.Run(fmt.Sprintf("num_nodes=%d", N), func(t *testing.T) {
@@ -122,7 +122,7 @@ func TestLocalNetwork_CanStartApplicatonsAndShutThemDown(t *testing.T) {
 func TestLocalNetwork_CanPerformNetworkShutdown(t *testing.T) {
 	t.Parallel()
 	N := 2
-	config := driver.NetworkConfig{NumberOfValidators: 1}
+	config := driver.NetworkConfig{MandatoryNumberOfValidators: 1}
 
 	net, err := NewLocalNetwork(&config)
 	if err != nil {
@@ -159,7 +159,7 @@ func TestLocalNetwork_CanRunWithMultipleValidators(t *testing.T) {
 	t.Parallel()
 	for _, N := range []int{1, 3} {
 		N := N
-		config := driver.NetworkConfig{NumberOfValidators: N}
+		config := driver.NetworkConfig{MandatoryNumberOfValidators: N}
 		t.Run(fmt.Sprintf("num_validators=%d", N), func(t *testing.T) {
 			t.Parallel()
 			net, err := NewLocalNetwork(&config)
@@ -190,7 +190,7 @@ func TestLocalNetwork_CanRunWithMultipleValidators(t *testing.T) {
 
 func TestLocalNetwork_NotifiesListenersOnNodeStartup(t *testing.T) {
 	t.Parallel()
-	config := driver.NetworkConfig{NumberOfValidators: 2}
+	config := driver.NetworkConfig{MandatoryNumberOfValidators: 2}
 	ctrl := gomock.NewController(t)
 	listener := driver.NewMockNetworkListener(ctrl)
 
@@ -203,7 +203,7 @@ func TestLocalNetwork_NotifiesListenersOnNodeStartup(t *testing.T) {
 	})
 
 	activeNodes := net.GetActiveNodes()
-	if got, want := len(activeNodes), config.NumberOfValidators; got != want {
+	if got, want := len(activeNodes), config.MandatoryNumberOfValidators; got != want {
 		t.Errorf("invalid number of active nodes, got %d, want %d", got, want)
 	}
 
@@ -215,7 +215,7 @@ func TestLocalNetwork_NotifiesListenersOnNodeStartup(t *testing.T) {
 	})
 
 	activeNodes = net.GetActiveNodes()
-	if got, want := len(activeNodes), config.NumberOfValidators+1; got != want {
+	if got, want := len(activeNodes), config.MandatoryNumberOfValidators+1; got != want {
 		t.Errorf("invalid number of active nodes, got %d, want %d", got, want)
 	}
 
@@ -223,7 +223,7 @@ func TestLocalNetwork_NotifiesListenersOnNodeStartup(t *testing.T) {
 
 func TestLocalNetwork_NotifiesListenersOnAppStartup(t *testing.T) {
 	t.Parallel()
-	config := driver.NetworkConfig{NumberOfValidators: 1}
+	config := driver.NetworkConfig{MandatoryNumberOfValidators: 1}
 	ctrl := gomock.NewController(t)
 	listener := driver.NewMockNetworkListener(ctrl)
 
@@ -248,7 +248,7 @@ func TestLocalNetwork_NotifiesListenersOnAppStartup(t *testing.T) {
 
 func TestLocalNetwork_CanRemoveNode(t *testing.T) {
 	t.Parallel()
-	config := driver.NetworkConfig{NumberOfValidators: 1}
+	config := driver.NetworkConfig{MandatoryNumberOfValidators: 1}
 	for _, N := range []int{1, 3} {
 		N := N
 		t.Run(fmt.Sprintf("num_nodes=%d", N), func(t *testing.T) {

--- a/driver/node/opera.go
+++ b/driver/node/opera.go
@@ -210,7 +210,7 @@ func (n *OperaNode) StreamLog() (io.ReadCloser, error) {
 
 func (n *OperaNode) Stop() error {
 	// SigInt repeatedly up to 9 times
-	if err := network.Retry(9, 1*time.Second, func() error {
+	if err := network.Retry(9, 5*time.Second, func() error {
 		if err := n.Interrupt(); err == nil {
 			return fmt.Errorf("failed to interrupt node %w", err)
 		} else {

--- a/driver/node/opera.go
+++ b/driver/node/opera.go
@@ -121,12 +121,14 @@ func StartOperaDockerNode(client *docker.Client, dn *docker.Network, config *Ope
 			ShutdownTimeout: &shutdownTimeout,
 			PortForwarding:  portForwarding,
 			Environment: map[string]string{
-				"VALIDATOR_ID":     validatorId,
-				"VALIDATORS_COUNT": fmt.Sprintf("%d", config.NetworkConfig.NumberOfValidators),
-				"MAX_BLOCK_GAS":    fmt.Sprintf("%d", config.NetworkConfig.MaxBlockGas),
-				"MAX_EPOCH_GAS":    fmt.Sprintf("%d", config.NetworkConfig.MaxEpochGas),
-				"STATE_DB_IMPL":    config.NetworkConfig.StateDbImplementation,
-				"VM_IMPL":          config.VmImplementation,
+				"NODE_LABEL":                config.Label,
+				"VALIDATOR_ID":              validatorId,
+				"TOTAL_VALIDATOR_COUNT":     fmt.Sprintf("%d", config.NetworkConfig.TotalNumberOfValidators),
+				"MANDATORY_VALIDATOR_COUNT": fmt.Sprintf("%d", config.NetworkConfig.MandatoryNumberOfValidators),
+				"MAX_BLOCK_GAS":             fmt.Sprintf("%d", config.NetworkConfig.MaxBlockGas),
+				"MAX_EPOCH_GAS":             fmt.Sprintf("%d", config.NetworkConfig.MaxEpochGas),
+				"STATE_DB_IMPL":             config.NetworkConfig.StateDbImplementation,
+				"VM_IMPL":                   config.VmImplementation,
 			},
 			Network:      dn,
 			MountDatadir: config.MountDatadir,
@@ -207,6 +209,9 @@ func (n *OperaNode) StreamLog() (io.ReadCloser, error) {
 }
 
 func (n *OperaNode) Stop() error {
+	if err := n.Interrupt(); err != nil {
+		return fmt.Errorf("failed to interrupt node %w", err)
+	}
 	return n.host.Stop()
 }
 
@@ -256,4 +261,9 @@ func (n *OperaNode) RemovePeer(id driver.NodeID) error {
 // Kill sends a SigKill singal to node.
 func (n *OperaNode) Kill() error {
 	return n.container.SendSignal(docker.SigKill)
+}
+
+// Interrupt sends a SigInt singal to node.
+func (n *OperaNode) Interrupt() error {
+	return n.container.SendSignal(docker.SigInt)
 }

--- a/driver/node/opera.go
+++ b/driver/node/opera.go
@@ -77,8 +77,9 @@ type OperaNode struct {
 type OperaNodeConfig struct {
 	// The label to be used to name this node. The label should not be empty.
 	Label string
-	// mount datadir to host if set.
-	Mount *string
+	// mount datadir, genesis to host if set.
+	MountDatadir *string
+	MountGenesis *string
 	// The ID of the validator, nil if the node should not be a validator.
 	ValidatorId *int
 	// The configuration of the network the configured node should be part of.
@@ -127,8 +128,9 @@ func StartOperaDockerNode(client *docker.Client, dn *docker.Network, config *Ope
 				"STATE_DB_IMPL":    config.NetworkConfig.StateDbImplementation,
 				"VM_IMPL":          config.VmImplementation,
 			},
-			Network: dn,
-			Mount:   config.Mount,
+			Network:      dn,
+			MountDatadir: config.MountDatadir,
+			MountGenesis: config.MountGenesis,
 		})
 	})
 	if err != nil {

--- a/driver/node/opera_test.go
+++ b/driver/node/opera_test.go
@@ -45,7 +45,7 @@ func TestOperaNode_StartAndStop(t *testing.T) {
 	})
 	node, err := StartOperaDockerNode(docker, nil, &OperaNodeConfig{
 		Label:         "test",
-		NetworkConfig: &driver.NetworkConfig{NumberOfValidators: 1},
+		NetworkConfig: &driver.NetworkConfig{MandatoryNumberOfValidators: 1},
 	})
 	t.Cleanup(func() {
 		_ = node.Cleanup()
@@ -72,7 +72,7 @@ func TestOperaNode_RpcServiceIsReadyAfterStartup(t *testing.T) {
 	})
 	node, err := StartOperaDockerNode(docker, nil, &OperaNodeConfig{
 		Label:         "test",
-		NetworkConfig: &driver.NetworkConfig{NumberOfValidators: 1},
+		NetworkConfig: &driver.NetworkConfig{MandatoryNumberOfValidators: 1},
 	})
 	t.Cleanup(func() {
 		_ = node.Cleanup()
@@ -100,7 +100,7 @@ func TestOperaNode_StreamLog(t *testing.T) {
 
 	node, err := StartOperaDockerNode(docker, nil, &OperaNodeConfig{
 		Label:         "test",
-		NetworkConfig: &driver.NetworkConfig{NumberOfValidators: 1},
+		NetworkConfig: &driver.NetworkConfig{MandatoryNumberOfValidators: 1},
 	})
 	if err != nil {
 		t.Fatalf("failed to create an Opera node on Docker: %v", err)
@@ -153,7 +153,7 @@ func TestOperaNode_MetricsExposed(t *testing.T) {
 
 	node, err := StartOperaDockerNode(docker, nil, &OperaNodeConfig{
 		Label:         "test",
-		NetworkConfig: &driver.NetworkConfig{NumberOfValidators: 1},
+		NetworkConfig: &driver.NetworkConfig{MandatoryNumberOfValidators: 1},
 	})
 	if err != nil {
 		t.Fatalf("failed to create an Opera node on Docker: %v", err)

--- a/driver/norma/run.go
+++ b/driver/norma/run.go
@@ -173,21 +173,25 @@ func run(ctx *cli.Context) (err error) {
 	clock := executor.NewWallTimeClock()
 
 	// Startup network.
-	netConfig := driver.NetworkConfig{
-		NumberOfValidators:    scenario.GetStaticValidatorCount(),
-		StateDbImplementation: db,
-		VmImplementation:      vm,
-		MaxBlockGas:           scenario.GetMaxBlockGas(),
-		MaxEpochGas:           scenario.GetMaxEpochGas(),
-	}
+	static, dynamic := scenario.GetStaticDynamicValidatorCount()
+	mandatory := scenario.GetMandatoryValidatorCount()
 
-	fmt.Printf("Creating network with %d static validator(s) using the `%v` DB and `%v` VM implementation ...\n",
-		netConfig.NumberOfValidators, netConfig.StateDbImplementation, netConfig.VmImplementation,
-	)
-	fmt.Printf("Network max block gas: %d\n", scenario.GetMaxBlockGas())
-	fmt.Printf("Network max epoch gas: %d\n", scenario.GetMaxEpochGas())
+	fmt.Printf("Creating network with: \n")
+	fmt.Printf("    Total number of validators: %d\n", static+dynamic+mandatory)
+	fmt.Printf("    Mandatory number of static validator: %d\n", mandatory)
+	fmt.Printf("    DB Implementation: `%v`\n", db)
+	fmt.Printf("    VM implementation: `%v`\n", vm)
+	fmt.Printf("    Network max block gas: %d\n", scenario.GetMaxBlockGas())
+	fmt.Printf("    Network max epoch gas: %d\n", scenario.GetMaxEpochGas())
 
-	net, err := local.NewLocalNetwork(&netConfig)
+	net, err := local.NewLocalNetwork(&driver.NetworkConfig{
+		TotalNumberOfValidators:     static + dynamic + mandatory,
+		MandatoryNumberOfValidators: mandatory,
+		StateDbImplementation:       db,
+		VmImplementation:            vm,
+		MaxBlockGas:                 scenario.GetMaxBlockGas(),
+		MaxEpochGas:                 scenario.GetMaxEpochGas(),
+	})
 	if err != nil {
 		return err
 	}

--- a/driver/norma/run.go
+++ b/driver/norma/run.go
@@ -251,7 +251,7 @@ func run(ctx *cli.Context) (err error) {
 	fmt.Printf("Running '%s' ...\n", path)
 	logger := startProgressLogger(monitor)
 	defer logger.shutdown()
-	err = executor.Run(clock, net, &scenario, outputDir)
+	err = executor.Run(clock, net, &scenario, outputDir, logger.epochTracker)
 	if err != nil {
 		return err
 	}
@@ -272,12 +272,14 @@ func run(ctx *cli.Context) (err error) {
 }
 
 type progressLogger struct {
-	monitor *monitoring.Monitor
-	stop    chan<- bool
-	done    <-chan bool
+	monitor      *monitoring.Monitor
+	epochTracker map[monitoring.Node]string
+	stop         chan<- bool
+	done         <-chan bool
 }
 
 func startProgressLogger(monitor *monitoring.Monitor) *progressLogger {
+	epochTracker := map[monitoring.Node]string{}
 	stop := make(chan bool)
 	done := make(chan bool)
 
@@ -289,13 +291,14 @@ func startProgressLogger(monitor *monitoring.Monitor) *progressLogger {
 			case <-stop:
 				return
 			case <-ticker.C:
-				logState(monitor)
+				logState(monitor, epochTracker)
 			}
 		}
 	}()
 
 	return &progressLogger{
 		monitor,
+		epochTracker,
 		stop,
 		done,
 	}
@@ -306,9 +309,9 @@ func (l *progressLogger) shutdown() {
 	<-l.done
 }
 
-func logState(monitor *monitoring.Monitor) {
+func logState(monitor *monitoring.Monitor, epochTracker map[monitoring.Node]string) {
 	numNodes := getNumNodes(monitor)
-	blockStatuses := getBlockStatuses(monitor)
+	blockStatuses := getBlockStatuses(monitor, epochTracker)
 	txPers := getTxPerSec(monitor)
 	txs := getNumTxs(monitor)
 	gas := getGasUsed(monitor)
@@ -329,7 +332,7 @@ func getNumTxs(monitor *monitoring.Monitor) string {
 
 func getTxPerSec(monitor *monitoring.Monitor) []string {
 	metric := nodemon.TransactionsThroughput
-	return getLastValAllSubjects[monitoring.BlockNumber, float32](monitor, metric)
+	return getLastValAllSubjects[monitoring.BlockNumber, float32](monitor, metric, nil)
 }
 
 func getGasUsed(monitor *monitoring.Monitor) string {
@@ -337,24 +340,29 @@ func getGasUsed(monitor *monitoring.Monitor) string {
 	return getLastValAsString[monitoring.BlockNumber, int](exists, data)
 }
 
-func getBlockStatuses(monitor *monitoring.Monitor) []string {
+func getBlockStatuses(monitor *monitoring.Monitor, epochTracker map[monitoring.Node]string) []string {
 	metric := nodemon.NodeBlockStatus
-	return getLastValAllSubjects[monitoring.Time, monitoring.BlockStatus, monitoring.Series[monitoring.Time, monitoring.BlockStatus]](monitor, metric)
+	return getLastValAllSubjects[monitoring.Time, monitoring.BlockStatus, monitoring.Series[monitoring.Time, monitoring.BlockStatus]](monitor, metric, epochTracker)
 }
 
 func getBlockProcessingTimes(monitor *monitoring.Monitor) []string {
 	metric := nodemon.BlockEventAndTxsProcessingTime
-	return getLastValAllSubjects[monitoring.BlockNumber, time.Duration, monitoring.Series[monitoring.BlockNumber, time.Duration]](monitor, metric)
+	return getLastValAllSubjects[monitoring.BlockNumber, time.Duration, monitoring.Series[monitoring.BlockNumber, time.Duration]](monitor, metric, nil)
 }
 
-func getLastValAllSubjects[K constraints.Ordered, T any, X monitoring.Series[K, T]](monitor *monitoring.Monitor, metric monitoring.Metric[monitoring.Node, X]) []string {
+func getLastValAllSubjects[K constraints.Ordered, T any, X monitoring.Series[K, T]](monitor *monitoring.Monitor, metric monitoring.Metric[monitoring.Node, X], epochTracker map[monitoring.Node]string) []string {
 	nodes := monitoring.GetSubjects(monitor, metric)
 	sort.Slice(nodes, func(i, j int) bool { return nodes[i] < nodes[j] })
 
 	res := make([]string, 0, len(nodes))
 	for _, node := range nodes {
 		data, exists := monitoring.GetData(monitor, node, metric)
-		res = append(res, getLastValAsString[K, T](exists, data))
+		var d string = getLastValAsString[K, T](exists, data)
+		res = append(res, d)
+
+		if epochTracker != nil {
+			epochTracker[node] = strings.Split(d, "/")[0]
+		}
 	}
 	return res
 }

--- a/driver/parser/check.go
+++ b/driver/parser/check.go
@@ -266,14 +266,16 @@ func (s *Scenario) GetStaticDynamicValidatorCount() (int, int) {
 // 1 if there is no validator in node list
 // 2 otherwise
 func (s *Scenario) GetMandatoryValidatorCount() int {
-	if len(s.Nodes) == 0 {
-		return 0
-	}
+	/*
+		if len(s.Nodes) == 0 {
+			return 0
+		}
 
-	static, dynamic := s.GetStaticDynamicValidatorCount()
-	if static+dynamic == 0 {
-		return 1
-	}
+		static, dynamic := s.GetStaticDynamicValidatorCount()
+		if static+dynamic == 0 {
+			return 1
+		}
+	*/
 
 	return 2
 }

--- a/driver/parser/check.go
+++ b/driver/parser/check.go
@@ -98,14 +98,14 @@ func (n *Node) Check(scenario *Scenario) error {
 		n.Timer = make(map[float32]string, 10)
 	}
 
-	if n.Genesis.Import != nil {
-		if err := isGenesisFile(*n.Genesis.Import, true); err != nil {
+	if n.Genesis.ImportInitial != nil {
+		if err := isGenesisFile(*n.Genesis.ImportInitial, true); err != nil {
 			errs = append(errs, err)
 		}
 	}
 
-	if n.Genesis.Export != nil {
-		if err := isGenesisFile(*n.Genesis.Export, false); err != nil {
+	if n.Genesis.ExportFinal != nil {
+		if err := isGenesisFile(*n.Genesis.ExportFinal, false); err != nil {
 			errs = append(errs, err)
 		}
 	}

--- a/driver/parser/check_test.go
+++ b/driver/parser/check_test.go
@@ -469,7 +469,7 @@ func TestScenario_NodeGenesisImportIssuesAreDetected(t *testing.T) {
 		Name:     "Test",
 		Duration: 60,
 		Nodes: []Node{
-			{Genesis: Genesis{Import: importFile}},
+			{Genesis: Genesis{ImportInitial: importFile}},
 		},
 	}
 	if err := scenario.Check(); err == nil || !strings.Contains(err.Error(), "provided genesis file does not exist") {
@@ -481,7 +481,7 @@ func TestScenario_NodeGenesisImportIssuesAreDetected(t *testing.T) {
 		Name:     "Test",
 		Duration: 60,
 		Nodes: []Node{
-			{Genesis: Genesis{Import: importFile}},
+			{Genesis: Genesis{ImportInitial: importFile}},
 		},
 	}
 	if err := scenario.Check(); err == nil || !strings.Contains(err.Error(), "provided path is not a genesis file") {
@@ -498,7 +498,7 @@ func TestScenario_NodeGenesisExportIssuesAreDetected(t *testing.T) {
 		Name:     "Test",
 		Duration: 60,
 		Nodes: []Node{
-			{Genesis: Genesis{Export: exportFile}},
+			{Genesis: Genesis{ExportFinal: exportFile}},
 		},
 	}
 

--- a/driver/parser/parser.go
+++ b/driver/parser/parser.go
@@ -119,8 +119,9 @@ func (n *Node) IsCheater() bool {
 // genesis file at the provided time.
 // GenesisExport will stop the client, export the genesis file and restart the client.
 type Genesis struct {
-	Import *string `yaml:",omitempty"`
-	Export *string `yaml:",omitempty"`
+	ImportInitial *string `yaml:",omitempty"`
+	ExportInitial *string `yaml:",omitempty"`
+	ExportFinal   *string `yaml:",omitempty"`
 }
 
 // ClientType is an optional configuration for Node.

--- a/driver/parser/parser_test.go
+++ b/driver/parser/parser_test.go
@@ -212,7 +212,7 @@ nodes:
     start: 5
     end: 7.5
     genesis:
-      import: /path/to/genesis
+      importinitial: /path/to/genesis
 
 applications:
   - name: lottery
@@ -243,7 +243,7 @@ func TestParseWithGenesisImportWorks(t *testing.T) {
 	}
 }
 
-// withGenesisImport extends the small scenario with genesis option.
+// withGenesisExport extends the small scenario with genesis option.
 var withGenesisExport = `
 name: Small Test With Genesis
 num_validators: 5
@@ -256,7 +256,7 @@ nodes:
     start: 5
     end: 7.5
     genesis:
-      export: /path/to/genesis
+      exportfinal: /path/to/genesis
 
 applications:
   - name: lottery

--- a/load/app/app_test.go
+++ b/load/app/app_test.go
@@ -34,7 +34,7 @@ const FakeNetworkID = 0xfa3
 
 func TestGenerators(t *testing.T) {
 	// run local network of one node
-	net, err := local.NewLocalNetwork(&driver.NetworkConfig{NumberOfValidators: 1})
+	net, err := local.NewLocalNetwork(&driver.NetworkConfig{MandatoryNumberOfValidators: 1})
 	if err != nil {
 		t.Fatalf("failed to create new local network: %v", err)
 	}

--- a/load/controller/rpc_test.go
+++ b/load/controller/rpc_test.go
@@ -33,7 +33,7 @@ const FakeNetworkID = 0xfa3
 
 func TestTrafficGenerating(t *testing.T) {
 	// run local network of one node
-	net, err := local.NewLocalNetwork(&driver.NetworkConfig{NumberOfValidators: 1})
+	net, err := local.NewLocalNetwork(&driver.NetworkConfig{MandatoryNumberOfValidators: 3})
 	if err != nil {
 		t.Fatalf("failed to create new local network: %v", err)
 	}

--- a/scenarios/export_events_30s.yml
+++ b/scenarios/export_events_30s.yml
@@ -1,5 +1,5 @@
 name: Event Export Simulation
-duration: 20 # 20s simulation time
+duration: 30 # 30s simulation time
 genesis_gas_limit: 
   max_block_gas: 38750000
   max_epoch_gas: 187500000
@@ -8,6 +8,7 @@ genesis_gas_limit:
 # Total amount of nodes in this scenarios = 5 (1 validators + 1 observer +2 = 4)
 nodes: 
   - name: validator
+    instances: 2
     client:
       type: validator   
     mount: tmp
@@ -20,7 +21,7 @@ applications:
     instances: 2
     type: ERC20
     start: 1          
-    end: 19
+    end: 29
     users: 10
     rate:
       constant: 200   # Tx/s

--- a/scenarios/export_events_5m.yml
+++ b/scenarios/export_events_5m.yml
@@ -8,6 +8,7 @@ genesis_gas_limit:
 # Total amount of nodes in this scenarios = 5 (1 validators + 1 observer +2 = 4)
 nodes: 
   - name: validator
+    instances: 2
     client:
       type: validator   
     mount: tmp

--- a/scenarios/export_events_5m.yml
+++ b/scenarios/export_events_5m.yml
@@ -8,7 +8,6 @@ genesis_gas_limit:
 # Total amount of nodes in this scenarios = 5 (1 validators + 1 observer +2 = 4)
 nodes: 
   - name: validator
-    instances: 2
     client:
       type: validator   
     mount: tmp
@@ -21,7 +20,7 @@ applications:
     instances: 2
     type: ERC20
     start: 1          
-    end: 299
+    end: 249
     users: 10
     rate:
-      constant: 200   # Tx/s
+      constant: 100   # Tx/s

--- a/scenarios/export_events_5m.yml
+++ b/scenarios/export_events_5m.yml
@@ -21,6 +21,6 @@ applications:
     type: ERC20
     start: 1          
     end: 249
-    users: 10
+    users: 5
     rate:
-      constant: 100   # Tx/s
+      constant: 50   # Tx/s

--- a/scripts/run_sonic_privatenet.sh
+++ b/scripts/run_sonic_privatenet.sh
@@ -15,8 +15,9 @@ echo "genesis validator count=${VALIDATORS_COUNT}"
 ./set_genesis.sh genesis.json 100 ${VALIDATORS_COUNT} ${MAX_BLOCK_GAS} ${MAX_EPOCH_GAS}
 
 # Initialize datadir
-mkdir /datadir
+mkdir /datadir /genesis
 ./sonictool --datadir ${datadir} genesis json --experimental genesis.json
+cp genesis.json /genesis
 
 ##
 ## if $VALIDATOR_ID is set, it is a validator

--- a/scripts/run_sonic_privatenet.sh
+++ b/scripts/run_sonic_privatenet.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+
+echo "I am ${NODE_LABEL}"
+
 # Get the local node's IP.
 list=`hostname -I`
 array=($list)
@@ -7,12 +10,13 @@ echo "Sonic is going to export its services on ${external_ip}"
 
 datadir="/datadir"
 echo "val id=${VALIDATOR_ID}"
-echo "genesis validator count=${VALIDATORS_COUNT}"
+echo "total validator count=${TOTAL_VALIDATOR_COUNT}"
+echo "mandatory validator count=${MANDATORY_VALIDATOR_COUNT}"
 
 # Call set genesis script - add balance to all possible validators
 # VALIDATOR_COUNT defines genesis validator count
 # TODO change 100 funded validator addresses to specific number
-./set_genesis.sh genesis.json 100 ${VALIDATORS_COUNT} ${MAX_BLOCK_GAS} ${MAX_EPOCH_GAS}
+./set_genesis.sh genesis.json ${TOTAL_VALIDATOR_COUNT} ${MANDATORY_VALIDATOR_COUNT} ${MAX_BLOCK_GAS} ${MAX_EPOCH_GAS}
 
 # Initialize datadir
 mkdir /datadir /genesis
@@ -59,6 +63,8 @@ else
 #  5 seconds in golang time 5*10^9 nanoseconds
   echo DoublesignProtection = 5000000000 >> config.toml
 fi
+
+trap "echo SIGINT; exit" SIGINT
 
 # Start sonic as part of a fake net with RPC service.
 ./sonicd \

--- a/scripts/run_sonic_privatenet.sh
+++ b/scripts/run_sonic_privatenet.sh
@@ -17,7 +17,7 @@ echo "genesis validator count=${VALIDATORS_COUNT}"
 # Initialize datadir
 mkdir /datadir /genesis
 ./sonictool --datadir ${datadir} genesis json --experimental genesis.json
-cp genesis.json /genesis
+cp genesis.json /genesis/genesis.init.json
 
 ##
 ## if $VALIDATOR_ID is set, it is a validator


### PR DESCRIPTION
Currently event exporting scenarios now have 1 validator each. We found that the validation is stuck at epoch 3 height 9 across the network. This does not happen when we have at least 2 validators, so the scenarios are modified as such.