### PR TITLE
[Fix] Uses SigInt to Gracefully shutdown client before stopping the container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,14 +40,18 @@ ENV STATE_DB_IMPL="geth"
 ENV VM_IMPL="geth"
 ENV LD_LIBRARY_PATH=./
 
-EXPOSE 5050
-EXPOSE 6060
-EXPOSE 18545
-EXPOSE 18546
+EXPOSE 5050 6060 18545 18546
 
 COPY genesis/example-genesis.json ./genesis.json
 COPY scripts/run_sonic_privatenet.sh ./run_sonic.sh
 COPY scripts/set_genesis.sh ./set_genesis.sh
 COPY build/normatool ./normatool
 
-CMD ["/bin/bash", "run_sonic.sh"]
+# Add https://github.com/krallin/tini
+ENV TINI_VERSION=v0.19.0
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
+RUN chmod +x /tini
+
+# -g forwards SIGINT to child processes and terminates client gracefully
+ENTRYPOINT ["/tini", "-g", "--"]
+CMD ["/bin/bash", "/run_sonic.sh"]

--- a/driver/docker/docker.go
+++ b/driver/docker/docker.go
@@ -41,6 +41,7 @@ const objectsLabel = "norma"
 type Signal string
 
 // SigHup is the SIGHUP signal.
+var SigInt Signal = "SIGINT"
 var SigHup Signal = "SIGHUP"
 var SigKill Signal = "SIGKILL"
 

--- a/driver/executor/executor.go
+++ b/driver/executor/executor.go
@@ -196,6 +196,11 @@ func scheduleNodeEvents(node *parser.Node, queue *eventQueue, net driver.Network
 	if node.End != nil {
 		endTime = Seconds(*node.End)
 	}
+	nodeIsValidator := false
+	if node.Client.Type == "validator" {
+		nodeIsValidator = true
+	}
+	nodeIsCheater := false
 	nodeImportEvent := ""
 	if node.Event.Import != nil {
 		nodeImportEvent = *node.Event.Import
@@ -267,12 +272,12 @@ func scheduleNodeEvents(node *parser.Node, queue *eventQueue, net driver.Network
 
 				newNode, err := net.CreateNode(&driver.NodeConfig{
 					Name:      name,
-					Validator: node.IsValidator(),
-					Cheater:   node.IsCheater(),
+					Validator: nodeIsValidator,
+					Cheater:   nodeIsCheater,
 					Mount:     mount,
 				})
-
 				*instance = newNode
+
 				return []event{importGenesis}, err
 			},
 		)

--- a/driver/monitoring/monitor_test.go
+++ b/driver/monitoring/monitor_test.go
@@ -169,7 +169,7 @@ func TestMonitorIntegrationPrometheusLogReceived(t *testing.T) {
 	})
 	node, err := opera.StartOperaDockerNode(client, nil, &opera.OperaNodeConfig{
 		Label:         "test",
-		NetworkConfig: &driver.NetworkConfig{NumberOfValidators: 1},
+		NetworkConfig: &driver.NetworkConfig{MandatoryNumberOfValidators: 1},
 	})
 	if err != nil {
 		t.Fatalf("failed to create an Opera node on Docker: %v", err)

--- a/driver/monitoring/node/cpu_profile_test.go
+++ b/driver/monitoring/node/cpu_profile_test.go
@@ -35,7 +35,7 @@ func TestCanCollectCpuProfileDateFromOperaNode(t *testing.T) {
 	})
 	node, err := opera.StartOperaDockerNode(docker, nil, &opera.OperaNodeConfig{
 		Label:         "test",
-		NetworkConfig: &driver.NetworkConfig{NumberOfValidators: 1},
+		NetworkConfig: &driver.NetworkConfig{MandatoryNumberOfValidators: 1},
 	})
 	if err != nil {
 		t.Fatalf("failed to create an Opera node on Docker: %v", err)

--- a/driver/monitoring/node/prom_log_source_test.go
+++ b/driver/monitoring/node/prom_log_source_test.go
@@ -100,7 +100,7 @@ func TestLogsIntegrationGetRealMetric(t *testing.T) {
 	})
 	node, err := opera.StartOperaDockerNode(client, nil, &opera.OperaNodeConfig{
 		Label:         "test",
-		NetworkConfig: &driver.NetworkConfig{NumberOfValidators: 1},
+		NetworkConfig: &driver.NetworkConfig{MandatoryNumberOfValidators: 1},
 	})
 	if err != nil {
 		t.Fatalf("failed to create an Opera node on Docker: %v", err)

--- a/driver/monitoring/prometheus/prometheus_test.go
+++ b/driver/monitoring/prometheus/prometheus_test.go
@@ -121,7 +121,7 @@ func startPrometheus(t *testing.T, net *local.LocalNetwork) *Prometheus {
 
 // createLocalNetwork creates a docker network and returns it.
 func createLocalNetwork(t *testing.T) *local.LocalNetwork {
-	config := driver.NetworkConfig{NumberOfValidators: 1}
+	config := driver.NetworkConfig{MandatoryNumberOfValidators: 1}
 	net, err := local.NewLocalNetwork(&config)
 	if err != nil {
 		t.Fatalf("error: %v", err)

--- a/driver/network.go
+++ b/driver/network.go
@@ -73,8 +73,10 @@ type Network interface {
 // NetworkConfig is a collection of network parameters to be used by factories
 // creating network instances.
 type NetworkConfig struct {
-	// NumberOfValidators is the (static) number of validators in the network.
-	NumberOfValidators int
+	// TotalNumberOfValidators is the total number of validators that appear in the scenario, including the additional mandatory ones.
+	TotalNumberOfValidators int
+	// NumberOfMandatoryValidators is minimum number of validators required for the network to function.
+	MandatoryNumberOfValidators int
 	// MaxBlockGas is the maximum gas limit for a block in the network.
 	MaxBlockGas uint64
 	// MaxEpochGas is the maximum gas limit for an epoch in the network.

--- a/driver/network/local/local.go
+++ b/driver/network/local/local.go
@@ -127,7 +127,7 @@ func NewLocalNetwork(config *driver.NetworkConfig) (*LocalNetwork, error) {
 			nodeConfig := node.OperaNodeConfig{
 				ValidatorId:      &validatorId,
 				NetworkConfig:    config,
-				Label:            fmt.Sprintf("_validator-%d", validatorId),
+				Label:            fmt.Sprintf("_validator-%d", i),
 				VmImplementation: config.VmImplementation,
 			}
 			net.validators[i], errs[i] = net.createNode(&nodeConfig)

--- a/driver/network/local/local.go
+++ b/driver/network/local/local.go
@@ -116,13 +116,12 @@ func NewLocalNetwork(config *driver.NetworkConfig) (*LocalNetwork, error) {
 	net.RegisterListener(net.rpcWorkerPool)
 
 	// Start all validators.
-	net.validators = make([]*node.OperaNode, config.NumberOfValidators)
-	errs := make([]error, config.NumberOfValidators)
+	net.validators = make([]*node.OperaNode, config.MandatoryNumberOfValidators)
+	errs := make([]error, config.MandatoryNumberOfValidators)
 	var wg sync.WaitGroup
-	for i := 0; i < config.NumberOfValidators; i++ {
+	for i := 0; i < config.MandatoryNumberOfValidators; i++ {
 		wg.Add(1)
-		i := i
-		go func() {
+		go func(i int) {
 			defer wg.Done()
 			validatorId := i + 1
 			nodeConfig := node.OperaNodeConfig{
@@ -132,7 +131,7 @@ func NewLocalNetwork(config *driver.NetworkConfig) (*LocalNetwork, error) {
 				VmImplementation: config.VmImplementation,
 			}
 			net.validators[i], errs[i] = net.createNode(&nodeConfig)
-		}()
+		}(i)
 	}
 	wg.Wait()
 

--- a/driver/network/local/local_test.go
+++ b/driver/network/local/local_test.go
@@ -31,7 +31,7 @@ func TestLocalNetworkIsNetwork(t *testing.T) {
 
 func TestLocalNetwork_CanStartNodesAndShutThemDown(t *testing.T) {
 	t.Parallel()
-	config := driver.NetworkConfig{NumberOfValidators: 1}
+	config := driver.NetworkConfig{MandatoryNumberOfValidators: 1}
 	for _, N := range []int{1, 3} {
 		N := N
 		t.Run(fmt.Sprintf("num_nodes=%d", N), func(t *testing.T) {
@@ -73,7 +73,7 @@ func TestLocalNetwork_CanStartNodesAndShutThemDown(t *testing.T) {
 
 func TestLocalNetwork_CanStartApplicatonsAndShutThemDown(t *testing.T) {
 	t.Parallel()
-	config := driver.NetworkConfig{NumberOfValidators: 1}
+	config := driver.NetworkConfig{MandatoryNumberOfValidators: 1}
 	for _, N := range []int{1, 3} {
 		N := N
 		t.Run(fmt.Sprintf("num_nodes=%d", N), func(t *testing.T) {
@@ -122,7 +122,7 @@ func TestLocalNetwork_CanStartApplicatonsAndShutThemDown(t *testing.T) {
 func TestLocalNetwork_CanPerformNetworkShutdown(t *testing.T) {
 	t.Parallel()
 	N := 2
-	config := driver.NetworkConfig{NumberOfValidators: 1}
+	config := driver.NetworkConfig{MandatoryNumberOfValidators: 1}
 
 	net, err := NewLocalNetwork(&config)
 	if err != nil {
@@ -159,7 +159,7 @@ func TestLocalNetwork_CanRunWithMultipleValidators(t *testing.T) {
 	t.Parallel()
 	for _, N := range []int{1, 3} {
 		N := N
-		config := driver.NetworkConfig{NumberOfValidators: N}
+		config := driver.NetworkConfig{MandatoryNumberOfValidators: N}
 		t.Run(fmt.Sprintf("num_validators=%d", N), func(t *testing.T) {
 			t.Parallel()
 			net, err := NewLocalNetwork(&config)
@@ -190,7 +190,7 @@ func TestLocalNetwork_CanRunWithMultipleValidators(t *testing.T) {
 
 func TestLocalNetwork_NotifiesListenersOnNodeStartup(t *testing.T) {
 	t.Parallel()
-	config := driver.NetworkConfig{NumberOfValidators: 2}
+	config := driver.NetworkConfig{MandatoryNumberOfValidators: 2}
 	ctrl := gomock.NewController(t)
 	listener := driver.NewMockNetworkListener(ctrl)
 
@@ -203,7 +203,7 @@ func TestLocalNetwork_NotifiesListenersOnNodeStartup(t *testing.T) {
 	})
 
 	activeNodes := net.GetActiveNodes()
-	if got, want := len(activeNodes), config.NumberOfValidators; got != want {
+	if got, want := len(activeNodes), config.MandatoryNumberOfValidators; got != want {
 		t.Errorf("invalid number of active nodes, got %d, want %d", got, want)
 	}
 
@@ -215,7 +215,7 @@ func TestLocalNetwork_NotifiesListenersOnNodeStartup(t *testing.T) {
 	})
 
 	activeNodes = net.GetActiveNodes()
-	if got, want := len(activeNodes), config.NumberOfValidators+1; got != want {
+	if got, want := len(activeNodes), config.MandatoryNumberOfValidators+1; got != want {
 		t.Errorf("invalid number of active nodes, got %d, want %d", got, want)
 	}
 
@@ -223,7 +223,7 @@ func TestLocalNetwork_NotifiesListenersOnNodeStartup(t *testing.T) {
 
 func TestLocalNetwork_NotifiesListenersOnAppStartup(t *testing.T) {
 	t.Parallel()
-	config := driver.NetworkConfig{NumberOfValidators: 1}
+	config := driver.NetworkConfig{MandatoryNumberOfValidators: 1}
 	ctrl := gomock.NewController(t)
 	listener := driver.NewMockNetworkListener(ctrl)
 
@@ -248,7 +248,7 @@ func TestLocalNetwork_NotifiesListenersOnAppStartup(t *testing.T) {
 
 func TestLocalNetwork_CanRemoveNode(t *testing.T) {
 	t.Parallel()
-	config := driver.NetworkConfig{NumberOfValidators: 1}
+	config := driver.NetworkConfig{MandatoryNumberOfValidators: 1}
 	for _, N := range []int{1, 3} {
 		N := N
 		t.Run(fmt.Sprintf("num_nodes=%d", N), func(t *testing.T) {

--- a/driver/node/opera.go
+++ b/driver/node/opera.go
@@ -208,7 +208,7 @@ func (n *OperaNode) StreamLog() (io.ReadCloser, error) {
 
 func (n *OperaNode) Stop() error {
 	// SigInt repeatedly up to 9 times
-	if err := network.Retry(9, 1*time.Second, func() error {
+	if err := network.Retry(9, 5*time.Second, func() error {
 		if err := n.Interrupt(); err == nil {
 			return fmt.Errorf("failed to interrupt node %w", err)
 		} else {

--- a/driver/node/opera.go
+++ b/driver/node/opera.go
@@ -207,10 +207,18 @@ func (n *OperaNode) StreamLog() (io.ReadCloser, error) {
 }
 
 func (n *OperaNode) Stop() error {
-	if err := n.Interrupt(); err != nil {
-		return fmt.Errorf("failed to interrupt node %w", err)
+	// SigInt repeatedly up to 9 times
+	if err := network.Retry(9, 1*time.Second, func() error {
+		if err := n.Interrupt(); err == nil {
+			return fmt.Errorf("failed to interrupt node %w", err)
+		} else {
+			return nil
+		}
+	}); err == nil {
+		return n.host.Stop()
 	}
-	return n.host.Stop()
+
+	return fmt.Errorf("failed to stop node")
 }
 
 func (n *OperaNode) Cleanup() error {

--- a/driver/node/opera_test.go
+++ b/driver/node/opera_test.go
@@ -45,7 +45,7 @@ func TestOperaNode_StartAndStop(t *testing.T) {
 	})
 	node, err := StartOperaDockerNode(docker, nil, &OperaNodeConfig{
 		Label:         "test",
-		NetworkConfig: &driver.NetworkConfig{NumberOfValidators: 1},
+		NetworkConfig: &driver.NetworkConfig{MandatoryNumberOfValidators: 1},
 	})
 	t.Cleanup(func() {
 		_ = node.Cleanup()
@@ -72,7 +72,7 @@ func TestOperaNode_RpcServiceIsReadyAfterStartup(t *testing.T) {
 	})
 	node, err := StartOperaDockerNode(docker, nil, &OperaNodeConfig{
 		Label:         "test",
-		NetworkConfig: &driver.NetworkConfig{NumberOfValidators: 1},
+		NetworkConfig: &driver.NetworkConfig{MandatoryNumberOfValidators: 1},
 	})
 	t.Cleanup(func() {
 		_ = node.Cleanup()
@@ -100,7 +100,7 @@ func TestOperaNode_StreamLog(t *testing.T) {
 
 	node, err := StartOperaDockerNode(docker, nil, &OperaNodeConfig{
 		Label:         "test",
-		NetworkConfig: &driver.NetworkConfig{NumberOfValidators: 1},
+		NetworkConfig: &driver.NetworkConfig{MandatoryNumberOfValidators: 1},
 	})
 	if err != nil {
 		t.Fatalf("failed to create an Opera node on Docker: %v", err)
@@ -153,7 +153,7 @@ func TestOperaNode_MetricsExposed(t *testing.T) {
 
 	node, err := StartOperaDockerNode(docker, nil, &OperaNodeConfig{
 		Label:         "test",
-		NetworkConfig: &driver.NetworkConfig{NumberOfValidators: 1},
+		NetworkConfig: &driver.NetworkConfig{MandatoryNumberOfValidators: 1},
 	})
 	if err != nil {
 		t.Fatalf("failed to create an Opera node on Docker: %v", err)

--- a/driver/norma/run.go
+++ b/driver/norma/run.go
@@ -173,21 +173,25 @@ func run(ctx *cli.Context) (err error) {
 	clock := executor.NewWallTimeClock()
 
 	// Startup network.
-	netConfig := driver.NetworkConfig{
-		NumberOfValidators:    scenario.GetStaticValidatorCount(),
-		StateDbImplementation: db,
-		VmImplementation:      vm,
-		MaxBlockGas:           scenario.GetMaxBlockGas(),
-		MaxEpochGas:           scenario.GetMaxEpochGas(),
-	}
+	static, dynamic := scenario.GetStaticDynamicValidatorCount()
+	mandatory := scenario.GetMandatoryValidatorCount()
 
-	fmt.Printf("Creating network with %d static validator(s) using the `%v` DB and `%v` VM implementation ...\n",
-		netConfig.NumberOfValidators, netConfig.StateDbImplementation, netConfig.VmImplementation,
-	)
-	fmt.Printf("Network max block gas: %d\n", scenario.GetMaxBlockGas())
-	fmt.Printf("Network max epoch gas: %d\n", scenario.GetMaxEpochGas())
+	fmt.Printf("Creating network with: \n")
+	fmt.Printf("    Total number of validators: %d\n", static+dynamic+mandatory)
+	fmt.Printf("    Mandatory number of static validator: %d\n", mandatory)
+	fmt.Printf("    DB Implementation: `%v`\n", db)
+	fmt.Printf("    VM implementation: `%v`\n", vm)
+	fmt.Printf("    Network max block gas: %d\n", scenario.GetMaxBlockGas())
+	fmt.Printf("    Network max epoch gas: %d\n", scenario.GetMaxEpochGas())
 
-	net, err := local.NewLocalNetwork(&netConfig)
+	net, err := local.NewLocalNetwork(&driver.NetworkConfig{
+		TotalNumberOfValidators:     static + dynamic + mandatory,
+		MandatoryNumberOfValidators: mandatory,
+		StateDbImplementation:       db,
+		VmImplementation:            vm,
+		MaxBlockGas:                 scenario.GetMaxBlockGas(),
+		MaxEpochGas:                 scenario.GetMaxEpochGas(),
+	})
 	if err != nil {
 		return err
 	}

--- a/load/app/app_test.go
+++ b/load/app/app_test.go
@@ -34,7 +34,7 @@ const FakeNetworkID = 0xfa3
 
 func TestGenerators(t *testing.T) {
 	// run local network of one node
-	net, err := local.NewLocalNetwork(&driver.NetworkConfig{NumberOfValidators: 1})
+	net, err := local.NewLocalNetwork(&driver.NetworkConfig{MandatoryNumberOfValidators: 1})
 	if err != nil {
 		t.Fatalf("failed to create new local network: %v", err)
 	}

--- a/load/controller/rpc_test.go
+++ b/load/controller/rpc_test.go
@@ -33,7 +33,7 @@ const FakeNetworkID = 0xfa3
 
 func TestTrafficGenerating(t *testing.T) {
 	// run local network of one node
-	net, err := local.NewLocalNetwork(&driver.NetworkConfig{NumberOfValidators: 1})
+	net, err := local.NewLocalNetwork(&driver.NetworkConfig{MandatoryNumberOfValidators: 3})
 	if err != nil {
 		t.Fatalf("failed to create new local network: %v", err)
 	}

--- a/scripts/run_sonic_privatenet.sh
+++ b/scripts/run_sonic_privatenet.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+
+echo "I am ${NODE_LABEL}"
+
 # Get the local node's IP.
 list=`hostname -I`
 array=($list)
@@ -7,12 +10,13 @@ echo "Sonic is going to export its services on ${external_ip}"
 
 datadir="/datadir"
 echo "val id=${VALIDATOR_ID}"
-echo "genesis validator count=${VALIDATORS_COUNT}"
+echo "total validator count=${TOTAL_VALIDATOR_COUNT}"
+echo "mandatory validator count=${MANDATORY_VALIDATOR_COUNT}"
 
 # Call set genesis script - add balance to all possible validators
 # VALIDATOR_COUNT defines genesis validator count
 # TODO change 100 funded validator addresses to specific number
-./set_genesis.sh genesis.json 100 ${VALIDATORS_COUNT} ${MAX_BLOCK_GAS} ${MAX_EPOCH_GAS}
+./set_genesis.sh genesis.json ${TOTAL_VALIDATOR_COUNT} ${MANDATORY_VALIDATOR_COUNT} ${MAX_BLOCK_GAS} ${MAX_EPOCH_GAS}
 
 # Initialize datadir
 mkdir /datadir
@@ -58,6 +62,8 @@ else
 #  5 seconds in golang time 5*10^9 nanoseconds
   echo DoublesignProtection = 5000000000 >> config.toml
 fi
+
+trap "echo SIGINT; exit" SIGINT
 
 # Start sonic as part of a fake net with RPC service.
 ./sonicd \


### PR DESCRIPTION
Currently, we gracefully stop the client by directly stopping the container (simulating `SigTerm`).
This results in sporadic dirty database if the container was stopped before the client gracefully shutdown.

The setup has been extended so that `SigInt` (Ctrl+C) can be propagated from Norma -> Container -> Client.
This `SigInt` is now used to signal graceful client stop before actually stopping the container.
