### PR TITLE
builds norma itself for docker in the build container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,11 @@ COPY client/ ./
 # Build sonic with caching
 RUN --mount=type=cache,target=/root/.cache/go-build make sonicd sonictool
 
+# Build norma itself
+WORKDIR /norma
+COPY . ./
+RUN --mount=type=cache,target=/root/.cache/go-build make normatool
+
 # This results in an image that contains the sonic binary
 #
 # The container can be run by typing:
@@ -34,7 +39,8 @@ RUN --mount=type=cache,target=/root/.cache/go-build make sonicd sonictool
 # > docker run -e VALIDATOR_NUMBER=2 -e VALIDATORS_COUNT=5 -i -t sonic
 #
 FROM debian:bookworm
-COPY --from=client-build /client/build/sonicd /client/build/sonictool .
+COPY --from=client-build /client/build/sonicd /client/build/sonictool ./
+COPY --from=client-build /norma/build/normatool ./
 
 ENV STATE_DB_IMPL="geth"
 ENV VM_IMPL="geth"
@@ -48,6 +54,5 @@ EXPOSE 18546
 COPY genesis/example-genesis.json ./genesis.json
 COPY scripts/run_sonic_privatenet.sh ./run_sonic.sh
 COPY scripts/set_genesis.sh ./set_genesis.sh
-COPY build/normatool ./normatool
 
 CMD ["/bin/bash", "run_sonic.sh"]


### PR DESCRIPTION
This PR updates build process of Norma for the docker environment in the way that Norma itself is build inside the container. 

Previous version was error prone, because guest and host systems may run (and often run) different architectures. When Norma is build at host system and copied into the container, it cannot be executed in the container once it runs on a different platform.

Example: Norma was build on a dev Mac, i.e. arm64 while the docker container runs amd64.  