### PR TITLE
Remove misleading VM and DB flags

### DIFF
--- a/driver/network.go
+++ b/driver/network.go
@@ -81,10 +81,6 @@ type NetworkConfig struct {
 	MaxBlockGas uint64
 	// MaxEpochGas is the maximum gas limit for an epoch in the network.
 	MaxEpochGas uint64
-	// The name of the StateDB implementation to be used by network nodes.
-	StateDbImplementation string
-	// The name of the EVM implementation to be used by network nodes.
-	VmImplementation string
 }
 
 // NetworkListener can be registered to networks to get callbacks whenever there

--- a/driver/network/local/local.go
+++ b/driver/network/local/local.go
@@ -126,10 +126,9 @@ func NewLocalNetwork(config *driver.NetworkConfig) (*LocalNetwork, error) {
 			defer wg.Done()
 			validatorId := i + 1
 			nodeConfig := node.OperaNodeConfig{
-				ValidatorId:      &validatorId,
-				NetworkConfig:    config,
-				Label:            fmt.Sprintf("_validator-%d", validatorId),
-				VmImplementation: config.VmImplementation,
+				ValidatorId:   &validatorId,
+				NetworkConfig: config,
+				Label:         fmt.Sprintf("_validator-%d", validatorId),
 			}
 			net.validators[i], errs[i] = net.createNode(&nodeConfig)
 		}()
@@ -204,12 +203,11 @@ func (n *LocalNetwork) CreateNode(config *driver.NodeConfig) (driver.Node, error
 
 	if config.Cheater {
 		_, err := n.createNode(&node.OperaNodeConfig{
-			Label:            "cheater-" + config.Name,
-			MountDatadir:     config.MountDatadir,
-			MountGenesis:     config.MountGenesis,
-			NetworkConfig:    &n.config,
-			VmImplementation: n.config.VmImplementation,
-			ValidatorId:      &newValId,
+			Label:         "cheater-" + config.Name,
+			MountDatadir:  config.MountDatadir,
+			MountGenesis:  config.MountGenesis,
+			NetworkConfig: &n.config,
+			ValidatorId:   &newValId,
 		})
 		if err != nil {
 			return nil, err
@@ -217,12 +215,11 @@ func (n *LocalNetwork) CreateNode(config *driver.NodeConfig) (driver.Node, error
 	}
 
 	return n.createNode(&node.OperaNodeConfig{
-		Label:            config.Name,
-		MountDatadir:     config.MountDatadir,
-		MountGenesis:     config.MountGenesis,
-		NetworkConfig:    &n.config,
-		VmImplementation: n.config.VmImplementation,
-		ValidatorId:      &newValId,
+		Label:         config.Name,
+		MountDatadir:  config.MountDatadir,
+		MountGenesis:  config.MountGenesis,
+		NetworkConfig: &n.config,
+		ValidatorId:   &newValId,
 	})
 }
 

--- a/driver/node/opera.go
+++ b/driver/node/opera.go
@@ -84,8 +84,6 @@ type OperaNodeConfig struct {
 	ValidatorId *int
 	// The configuration of the network the configured node should be part of.
 	NetworkConfig *driver.NetworkConfig
-	// The EVM implementation to be used on this node.
-	VmImplementation string
 	// ValidatorPubkey is nil if not a validator, else used as pubkey for the validator.
 	ValidatorPubkey *string
 }
@@ -125,8 +123,6 @@ func StartOperaDockerNode(client *docker.Client, dn *docker.Network, config *Ope
 				"VALIDATORS_COUNT": fmt.Sprintf("%d", config.NetworkConfig.NumberOfValidators),
 				"MAX_BLOCK_GAS":    fmt.Sprintf("%d", config.NetworkConfig.MaxBlockGas),
 				"MAX_EPOCH_GAS":    fmt.Sprintf("%d", config.NetworkConfig.MaxEpochGas),
-				"STATE_DB_IMPL":    config.NetworkConfig.StateDbImplementation,
-				"VM_IMPL":          config.VmImplementation,
 			},
 			Network:      dn,
 			MountDatadir: config.MountDatadir,


### PR DESCRIPTION
This PR removes two flags that are no longer effective (both options are hard-coded in the client):
- `--vm-impl` ... switch between different VM implementations; Sonic uses LFVM for everything but tracing
- `--db-impl` ... switch between different DB implementations; Sonic always uses Carmen 