### PR TITLE
[QoL] Ended nodes now disapppear from live log

### DIFF
--- a/driver/monitoring/utils/periodic_source.go
+++ b/driver/monitoring/utils/periodic_source.go
@@ -141,12 +141,20 @@ func (s *PeriodicDataSource[S, T]) AddSubject(subject S, sensor Sensor[T]) error
 	return nil
 }
 
+// GetSubjects returns only the "live" subjects.
+func (s *PeriodicDataSource[S, T]) GetSubjects() []S {
+	res := make([]S, 0, len(s.subjects))
+	for subject := range s.subjects {
+		res = append(res, subject)
+	}
+	return res
+}
+
 func (s *PeriodicDataSource[S, T]) RemoveSubject(subject S) error {
 	subjectStop, exists := s.subjects[subject]
 	if exists {
 		delete(s.subjects, subject)
 		return subjectStop.Stop()
 	}
-
 	return nil
 }

--- a/scenarios/test/baseline_check.yml
+++ b/scenarios/test/baseline_check.yml
@@ -7,6 +7,10 @@ name: Baseline Check
 duration: 60
 num_validators: 2
 
+nodes:
+  - name: observer
+    end: 30
+
 # In the network there is a single application producing constant load.
 applications:
   - name: load


### PR DESCRIPTION
Currently, when a node ends, the latest value for the node will still be tracked and displayed:
```
duration: 60
nodes:
  - name: observer
    end: 30
```

At time 40:
```
Nodes: 2, 
block heights: [3/20 3/20 3/15],  # observer irrelevant,
tx/s: [33.58209 33.58209 1.8621974],  # observer irrelevant
txs: 9, 
gas: 258237, 
block processing: [2.378ms 2.928ms 781.976µs]  # observer irrelevant
```

This PR addresses this by making sure that the live tracker is using different tracker than historical data tracker.