### PR TITLE
Add downloading of dependency as an extra docker build step

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,19 @@
 # The build is done in independent stages, to allow for
 # caching of the intermediate results.
 
+# Stage 0: load dependencies
+FROM golang:1.22 AS client-dependencies
+
+WORKDIR /client
+COPY client/go.mod ./go.mod
+RUN go mod download
+
+WORKDIR /
+COPY go.mod go.mod
+RUN go mod download
+
 # Stage 1: build the client
-FROM golang:1.22 AS client-build
+FROM client-dependencies AS client-build
 
 WORKDIR /client
 


### PR DESCRIPTION
This change can save minutes of build time in the development loop since dependencies are downloaded only once and then cached by docker as long as the `go.mod` files do not change.