### PR TITLE
fixes log to reflect active nodes

### DIFF
--- a/driver/norma/progress.go
+++ b/driver/norma/progress.go
@@ -1,0 +1,169 @@
+package main
+
+import (
+	"fmt"
+	"github.com/Fantom-foundation/Norma/driver"
+	"github.com/Fantom-foundation/Norma/driver/monitoring"
+	netmon "github.com/Fantom-foundation/Norma/driver/monitoring/network"
+	nodemon "github.com/Fantom-foundation/Norma/driver/monitoring/node"
+	"github.com/Fantom-foundation/Norma/driver/network/local"
+	"golang.org/x/exp/constraints"
+	"log"
+	"sort"
+	"sync"
+	"time"
+)
+
+// progressLogger is a helper struct that logs the progress of the network.
+// It lists nodes and logs the progress of the network periodically.
+type progressLogger struct {
+	monitor *monitoring.Monitor
+	stop    chan<- bool
+	done    <-chan bool
+}
+
+// startProgressLogger starts a progress logger that logs the progress of the network.
+func startProgressLogger(monitor *monitoring.Monitor, net *local.LocalNetwork) *progressLogger {
+	stop := make(chan bool)
+	done := make(chan bool)
+
+	activeNodes := &activeNodes{
+		data: make(map[driver.NodeID]struct{}),
+	}
+	net.RegisterListener(activeNodes)
+	for _, node := range net.GetActiveNodes() {
+		activeNodes.AfterNodeCreation(node)
+	}
+
+	go func() {
+		defer close(done)
+		ticker := time.NewTicker(time.Second)
+		for {
+			select {
+			case <-stop:
+				return
+			case <-ticker.C:
+				logState(monitor, activeNodes)
+			}
+		}
+	}()
+
+	return &progressLogger{
+		monitor,
+		stop,
+		done,
+	}
+}
+
+type activeNodes struct {
+	data  map[driver.NodeID]struct{}
+	mutex sync.Mutex
+}
+
+func (l *activeNodes) AfterNodeCreation(node driver.Node) {
+	l.mutex.Lock()
+	defer l.mutex.Unlock()
+	l.data[driver.NodeID(node.GetLabel())] = struct{}{}
+}
+
+func (l *activeNodes) AfterNodeRemoval(node driver.Node) {
+	l.mutex.Lock()
+	defer l.mutex.Unlock()
+	delete(l.data, driver.NodeID(node.GetLabel()))
+}
+
+func (l *activeNodes) AfterApplicationCreation(app driver.Application) {
+	// noop
+}
+
+func (l *activeNodes) containsId(id driver.NodeID) bool {
+	l.mutex.Lock()
+	defer l.mutex.Unlock()
+
+	_, exists := l.data[id]
+	return exists
+}
+
+func (l *progressLogger) shutdown() {
+	close(l.stop)
+	<-l.done
+}
+
+func logState(monitor *monitoring.Monitor, nodes *activeNodes) {
+	numNodes := getNumNodes(monitor)
+	blockStatuses := getBlockStatuses(monitor, nodes)
+	txPers := getTxPerSec(monitor, nodes)
+	txs := getNumTxs(monitor)
+	gas := getGasUsed(monitor)
+	processingTimes := getBlockProcessingTimes(monitor, nodes)
+
+	log.Printf("Nodes: %s, block heights: %v, tx/s: %v, txs: %v, gas: %s, block processing: %v", numNodes, blockStatuses, txPers, txs, gas, processingTimes)
+}
+
+func getNumNodes(monitor *monitoring.Monitor) string {
+	data, exists := monitoring.GetData(monitor, monitoring.Network{}, netmon.NumberOfNodes)
+	return getLastValAsString[monitoring.Time, int](exists, data)
+}
+
+func getNumTxs(monitor *monitoring.Monitor) string {
+	data, exists := monitoring.GetData(monitor, monitoring.Network{}, netmon.BlockNumberOfTransactions)
+	return getLastValAsString[monitoring.BlockNumber, int](exists, data)
+}
+
+func getTxPerSec(monitor *monitoring.Monitor, nodes *activeNodes) []string {
+	metric := nodemon.TransactionsThroughput
+	return getLastValAllSubjects[monitoring.BlockNumber, float32](monitor, metric, nodes)
+}
+
+func getGasUsed(monitor *monitoring.Monitor) string {
+	data, exists := monitoring.GetData(monitor, monitoring.Network{}, netmon.BlockGasUsed)
+	return getLastValAsString[monitoring.BlockNumber, int](exists, data)
+}
+
+func getBlockStatuses(monitor *monitoring.Monitor, nodes *activeNodes) []string {
+	metric := nodemon.NodeBlockStatus
+	return getLastValAllSubjects[
+		monitoring.Time,
+		monitoring.BlockStatus,
+		monitoring.Series[monitoring.Time, monitoring.BlockStatus]](
+		monitor, metric, nodes)
+}
+
+func getBlockProcessingTimes(monitor *monitoring.Monitor, nodes *activeNodes) []string {
+	metric := nodemon.BlockEventAndTxsProcessingTime
+	return getLastValAllSubjects[
+		monitoring.BlockNumber,
+		time.Duration,
+		monitoring.Series[monitoring.BlockNumber, time.Duration]](
+		monitor, metric, nodes)
+}
+
+func getLastValAllSubjects[K constraints.Ordered, T any, X monitoring.Series[K, T]](
+	monitor *monitoring.Monitor,
+	metric monitoring.Metric[monitoring.Node, X],
+	activeNodes *activeNodes) []string {
+
+	nodes := monitoring.GetSubjects(monitor, metric)
+	sort.Slice(nodes, func(i, j int) bool { return nodes[i] < nodes[j] })
+
+	res := make([]string, 0, len(nodes))
+	for _, node := range nodes {
+		if exists := activeNodes.containsId(driver.NodeID(node)); exists {
+			data, exists := monitoring.GetData(monitor, node, metric)
+			d := getLastValAsString[K, T](exists, data)
+			res = append(res, d)
+		}
+	}
+	return res
+}
+
+func getLastValAsString[K constraints.Ordered, T any](exists bool, series monitoring.Series[K, T]) string {
+	if !exists || series == nil {
+		return "N/A"
+	}
+	point := series.GetLatest()
+	if point == nil {
+		return "N/A"
+	}
+	return fmt.Sprintf("%v", point.Value)
+}

--- a/driver/norma/progress_test.go
+++ b/driver/norma/progress_test.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"fmt"
+	"github.com/Fantom-foundation/Norma/driver"
+	"go.uber.org/mock/gomock"
+	"math/rand"
+	"testing"
+)
+
+func TestActiveNodes_TrackActiveNodes(t *testing.T) {
+	nodes := activeNodes{
+		data: make(map[driver.NodeID]struct{}),
+	}
+
+	shadow := make(map[driver.NodeID]struct{})
+	const N = 100
+
+	ctrl := gomock.NewController(t)
+	for i := 0; i < N; i++ {
+		id := fmt.Sprintf("%d", i)
+		shadow[driver.NodeID(id)] = struct{}{}
+		node := driver.NewMockNode(ctrl)
+		node.EXPECT().GetLabel().Return(id)
+		nodes.AfterNodeCreation(node)
+	}
+
+	for i := 0; i < N; i++ {
+		r := rand.Intn(2)
+		if r == 0 {
+			id := fmt.Sprintf("%d", i)
+			node := driver.NewMockNode(ctrl)
+			node.EXPECT().GetLabel().Return(id)
+			delete(shadow, driver.NodeID(id))
+			nodes.AfterNodeRemoval(node)
+		}
+	}
+
+	for i := 0; i < N; i++ {
+		id := driver.NodeID(fmt.Sprintf("%d", i))
+		_, exists := shadow[id]
+		if got, want := nodes.containsId(id), exists; got != want {
+			t.Errorf("sahdow and active nodes do not match: got: %v != want: %v", got, want)
+		}
+	}
+}

--- a/driver/norma/run.go
+++ b/driver/norma/run.go
@@ -19,10 +19,8 @@ package main
 import (
 	"fmt"
 	"io/ioutil"
-	"log"
 	"os"
 	"path/filepath"
-	"sort"
 	"time"
 
 	"github.com/Fantom-foundation/Norma/driver/checking"
@@ -32,14 +30,11 @@ import (
 	"github.com/Fantom-foundation/Norma/driver/executor"
 	"github.com/Fantom-foundation/Norma/driver/monitoring"
 	_ "github.com/Fantom-foundation/Norma/driver/monitoring/app"
-	netmon "github.com/Fantom-foundation/Norma/driver/monitoring/network"
-	nodemon "github.com/Fantom-foundation/Norma/driver/monitoring/node"
 	prometheusmon "github.com/Fantom-foundation/Norma/driver/monitoring/prometheus"
 	_ "github.com/Fantom-foundation/Norma/driver/monitoring/user"
 	"github.com/Fantom-foundation/Norma/driver/network/local"
 	"github.com/Fantom-foundation/Norma/driver/parser"
 	"github.com/urfave/cli/v2"
-	"golang.org/x/exp/constraints"
 )
 
 // Run with `go run ./driver/norma run <scenario.yml>`
@@ -215,7 +210,7 @@ func run(ctx *cli.Context) (err error) {
 
 	// Run scenario.
 	fmt.Printf("Running '%s' ...\n", path)
-	logger := startProgressLogger(monitor)
+	logger := startProgressLogger(monitor, net)
 	defer logger.shutdown()
 	err = executor.Run(clock, net, &scenario, outputDir)
 	if err != nil {
@@ -235,104 +230,4 @@ func run(ctx *cli.Context) (err error) {
 	}
 
 	return nil
-}
-
-type progressLogger struct {
-	monitor *monitoring.Monitor
-	stop    chan<- bool
-	done    <-chan bool
-}
-
-func startProgressLogger(monitor *monitoring.Monitor) *progressLogger {
-	stop := make(chan bool)
-	done := make(chan bool)
-
-	go func() {
-		defer close(done)
-		ticker := time.NewTicker(time.Second)
-		for {
-			select {
-			case <-stop:
-				return
-			case <-ticker.C:
-				logState(monitor)
-			}
-		}
-	}()
-
-	return &progressLogger{
-		monitor,
-		stop,
-		done,
-	}
-}
-
-func (l *progressLogger) shutdown() {
-	close(l.stop)
-	<-l.done
-}
-
-func logState(monitor *monitoring.Monitor) {
-	numNodes := getNumNodes(monitor)
-	blockStatuses := getBlockStatuses(monitor)
-	txPers := getTxPerSec(monitor)
-	txs := getNumTxs(monitor)
-	gas := getGasUsed(monitor)
-	processingTimes := getBlockProcessingTimes(monitor)
-
-	log.Printf("Nodes: %s, block heights: %v, tx/s: %v, txs: %v, gas: %s, block processing: %v", numNodes, blockStatuses, txPers, txs, gas, processingTimes)
-}
-
-func getNumNodes(monitor *monitoring.Monitor) string {
-	data, exists := monitoring.GetData(monitor, monitoring.Network{}, netmon.NumberOfNodes)
-	return getLastValAsString[monitoring.Time, int](exists, data)
-}
-
-func getNumTxs(monitor *monitoring.Monitor) string {
-	data, exists := monitoring.GetData(monitor, monitoring.Network{}, netmon.BlockNumberOfTransactions)
-	return getLastValAsString[monitoring.BlockNumber, int](exists, data)
-}
-
-func getTxPerSec(monitor *monitoring.Monitor) []string {
-	metric := nodemon.TransactionsThroughput
-	return getLastValAllSubjects[monitoring.BlockNumber, float32](monitor, metric)
-}
-
-func getGasUsed(monitor *monitoring.Monitor) string {
-	data, exists := monitoring.GetData(monitor, monitoring.Network{}, netmon.BlockGasUsed)
-	return getLastValAsString[monitoring.BlockNumber, int](exists, data)
-}
-
-func getBlockStatuses(monitor *monitoring.Monitor) []string {
-	metric := nodemon.NodeBlockStatus
-	return getLastValAllSubjects[monitoring.Time, monitoring.BlockStatus, monitoring.Series[monitoring.Time, monitoring.BlockStatus]](monitor, metric)
-}
-
-func getBlockProcessingTimes(monitor *monitoring.Monitor) []string {
-	metric := nodemon.BlockEventAndTxsProcessingTime
-	return getLastValAllSubjects[monitoring.BlockNumber, time.Duration, monitoring.Series[monitoring.BlockNumber, time.Duration]](monitor, metric)
-}
-
-func getLastValAllSubjects[K constraints.Ordered, T any, X monitoring.Series[K, T]](monitor *monitoring.Monitor, metric monitoring.Metric[monitoring.Node, X]) []string {
-	nodes := monitoring.GetSubjects(monitor, metric)
-	sort.Slice(nodes, func(i, j int) bool { return nodes[i] < nodes[j] })
-
-	res := make([]string, 0, len(nodes))
-	for _, node := range nodes {
-		data, exists := monitoring.GetData(monitor, node, metric)
-		var d string = getLastValAsString[K, T](exists, data)
-		res = append(res, d)
-	}
-	return res
-}
-
-func getLastValAsString[K constraints.Ordered, T any](exists bool, series monitoring.Series[K, T]) string {
-	if !exists || series == nil {
-		return "N/A"
-	}
-	point := series.GetLatest()
-	if point == nil {
-		return "N/A"
-	}
-	return fmt.Sprintf("%v", point.Value)
 }

--- a/scenarios/various_nodes.yml
+++ b/scenarios/various_nodes.yml
@@ -17,34 +17,33 @@ nodes:
   # Gradually increase the number of nodes 
   - name: A
     start: 0          # start time
-    end: 600            # termination time
+    end: 100            # termination time
     instances: 0
 
   - name: B
     start: 120          # start time
-    end: 600            # termination time
-    instances: 4
+    end: 200            # termination time
+    instances: 3
 
   - name: C
     start: 240          # start time
-    end: 600            # termination time
-    instances: 5
+    end: 300            # termination time
+    instances: 3
 
   - name: D
     start: 360          # start time
-    end: 600            # termination time
-    instances: 10
+    end: 450            # termination time
+    instances: 4
 
   - name: E
     start: 480          # start time
     end: 600            # termination time
-    instances: 10
-
+    instances: 4
 
 # In the network there is a single application producing constant load.
 applications:
   - name: load
     type: counter
-    users: 200           # number of users using the app
+    users: 20           # number of users using the app
     rate:
-      constant: 2000     # Tx/s
+      constant: 2     # Tx/s


### PR DESCRIPTION
This PR fixes log of experiment run to show information only about Nodes that are currently active. 

It was done by extnding the logger with a new struct that listens for added/removed nodes, and prints only the nodes that are present in the network. 

An existing scenario was updated to start and stop nodes within a scenario run