### PR TITLE
Fix number of users in baseline test case

### DIFF
--- a/scenarios/test/baseline_check.yml
+++ b/scenarios/test/baseline_check.yml
@@ -11,6 +11,7 @@ num_validators: 2
 applications:
   - name: load
     type: counter
+    users: 50
     start: 10          # start time
     end: 50            # termination time
     rate:


### PR DESCRIPTION
Fixes the number of users participating in the baseline check.

Before this change, the entire load was issued by a single user. A single user, however, is limited in the number of transactions that are accepted per second. With this change, the incoming load in the network is as specified.