### PR TITLE
Add tracking of Gas rates and Base-Fees

### DIFF
--- a/analysis/report/single_eval_report.Rmd
+++ b/analysis/report/single_eval_report.Rmd
@@ -93,7 +93,7 @@ ggplot(data = data) +
 
 
 ### Gas Rate per Block
-The following chart shows the Gas Rate per block and a trend line showing long-term trends.
+The following chart shows the Gas Rate per block and a trend line.
 
 ```{r gas_rate_per_block, echo=FALSE, message=FALSE, fig.dim = figure_dimensions}
 data <- all_data %>%
@@ -111,7 +111,7 @@ ggplot(data=data) +
 
 
 ### Gas Base-Fee per Block
-The following chart shows the Gas Base-Fee per block and a trend line showing long-term trends.
+The following chart shows the Gas Base-Fee per block and a trend line.
 
 ```{r gas_base_fee_per_block, echo=FALSE, message=FALSE, fig.dim = figure_dimensions}
 data <- all_data %>%

--- a/analysis/report/single_eval_report.Rmd
+++ b/analysis/report/single_eval_report.Rmd
@@ -92,6 +92,24 @@ ggplot(data = data) +
 ```
 
 
+### Gas Rate per Block
+The following chart shows the Gas Rate per block and a trend line showing long-term trends.
+
+```{r gas_rate_per_block, echo=FALSE, message=FALSE, fig.dim = figure_dimensions}
+data <- all_data %>%
+    dplyr::filter(metric == "BlockGasRate") %>%    # filter metric of interrest
+    mutate(value = as.numeric(value))              # convert value to int
+
+ggplot(data=data) +
+    geom_point(aes(x=block, y=value)) +               # the data points
+    geom_smooth(aes(x=block, y=value), se=FALSE) +    # a trend line
+    ggtitle("Gas Rate per Block") +                   # chart title
+    xlab("Block Height") +                            # x-axis title
+    ylab("Gas per Second") +                          # y-axis title
+    theme(plot.title = element_text(hjust = 0.5))     # center title
+```
+
+
 ### Gas Base-Fee per Block
 The following chart shows the Gas Base-Fee per block and a trend line showing long-term trends.
 

--- a/analysis/report/single_eval_report.Rmd
+++ b/analysis/report/single_eval_report.Rmd
@@ -92,6 +92,23 @@ ggplot(data = data) +
 ```
 
 
+### Gas Base-Fee per Block
+The following chart shows the Gas Base-Fee per block and a trend line showing long-term trends.
+
+```{r gas_base_fee_per_block, echo=FALSE, message=FALSE, fig.dim = figure_dimensions}
+data <- all_data %>%
+    dplyr::filter(metric == "BlockGasBaseFee") %>%    # filter metric of interrest
+    mutate(value = as.numeric(value))              # convert value to int
+
+ggplot(data=data) +
+    geom_point(aes(x=block, y=value)) +               # the data points
+    geom_smooth(aes(x=block, y=value), se=FALSE) +    # a trend line
+    ggtitle("Gas Base Fee per Block") +               # chart title
+    xlab("Block Height") +                            # x-axis title
+    ylab("Gas Base Fee") +                            # y-axis title
+    theme(plot.title = element_text(hjust = 0.5))     # center title
+```
+
 ## Network Metrics
 
 This section covers metrics that are network wide properties.

--- a/driver/docker/docker.go
+++ b/driver/docker/docker.go
@@ -254,8 +254,7 @@ func (c *Container) Cleanup() error {
 		return err
 	}
 	c.cleaned = true
-	// return c.client.cli.ContainerRemove(context.Background(), c.id, container.RemoveOptions{})
-	return nil
+	return c.client.cli.ContainerRemove(context.Background(), c.id, container.RemoveOptions{})
 }
 
 // GetAddressForService retrieves the Address of a service running in this

--- a/driver/docker/docker.go
+++ b/driver/docker/docker.go
@@ -254,7 +254,8 @@ func (c *Container) Cleanup() error {
 		return err
 	}
 	c.cleaned = true
-	return c.client.cli.ContainerRemove(context.Background(), c.id, container.RemoveOptions{})
+	// return c.client.cli.ContainerRemove(context.Background(), c.id, container.RemoveOptions{})
+	return nil
 }
 
 // GetAddressForService retrieves the Address of a service running in this

--- a/driver/monitoring/logreader.go
+++ b/driver/monitoring/logreader.go
@@ -31,7 +31,7 @@ var (
 	timestampReg      = regexp.MustCompile(`\[\S*\]`)
 	blockReg          = regexp.MustCompile(`index=\d*`)
 	gasReg            = regexp.MustCompile(`gas_used=\S*`)
-	gasRateReg        = regexp.MustCompile(`gas_rate=\d+(.\d*)?`)
+	gasRateReg        = regexp.MustCompile(`gas_rate=\d+(\.\d*)?`)
 	baseFeeReg        = regexp.MustCompile(`base_fee=\d+`)
 	txsReg            = regexp.MustCompile(`txs=\d+`)
 	processingTimeReg = regexp.MustCompile(`t=\S*`)
@@ -83,7 +83,7 @@ func parseTime(str string) (time.Time, error) {
 
 // parseBlock parses block information from the log line. It is expected the log line is well-formed.
 func parseBlock(line string) (block Block, err error) {
-	// example line: "INFO [05-04|09:34:15.537] New block index=3 id=3:1:3d6fb6 gas_used=117,867 base_fee=123 txs=1/0 age=343.255ms t=1.579ms
+	// example line: "INFO [05-04|09:34:15.537] New block index=3 id=3:1:3d6fb6 gas_used=117,867 base_fee=123 gas_rate=1.23 txs=1/0 age=343.255ms t=1.579ms
 	timestampStr := timestampReg.FindString(line)
 	blockNumberStr := strings.Split(blockReg.FindString(line), "=")[1]
 	gasUsedStr := strings.ReplaceAll(strings.Split(gasReg.FindString(line), "=")[1], ",", "")

--- a/driver/monitoring/logreader.go
+++ b/driver/monitoring/logreader.go
@@ -31,6 +31,7 @@ var (
 	timestampReg      = regexp.MustCompile(`\[\S*\]`)
 	blockReg          = regexp.MustCompile(`index=\d*`)
 	gasReg            = regexp.MustCompile(`gas_used=\S*`)
+	gasRateReg        = regexp.MustCompile(`gas_rate=\d+(.\d*)?`)
 	baseFeeReg        = regexp.MustCompile(`base_fee=\d+`)
 	txsReg            = regexp.MustCompile(`txs=\d+`)
 	processingTimeReg = regexp.MustCompile(`t=\S*`)
@@ -86,6 +87,7 @@ func parseBlock(line string) (block Block, err error) {
 	timestampStr := timestampReg.FindString(line)
 	blockNumberStr := strings.Split(blockReg.FindString(line), "=")[1]
 	gasUsedStr := strings.ReplaceAll(strings.Split(gasReg.FindString(line), "=")[1], ",", "")
+	gasRateStr := strings.Split(gasRateReg.FindString(line), "=")[1]
 	baseFeeStr := strings.Split(baseFeeReg.FindString(line), "=")[1]
 	txsStr := strings.Split(txsReg.FindString(line), "=")[1]
 	processingTimeStr := strings.Trim(strings.Split(processingTimeReg.FindString(line), "=")[1], "\"")
@@ -110,6 +112,11 @@ func parseBlock(line string) (block Block, err error) {
 		return block, err
 	}
 
+	gasRate, err := strconv.ParseFloat(gasRateStr, 64)
+	if err != nil {
+		return block, err
+	}
+
 	baseFeeUsed, err := strconv.Atoi(baseFeeStr)
 	if err != nil {
 		return block, err
@@ -127,6 +134,7 @@ func parseBlock(line string) (block Block, err error) {
 		Time:           timestamp,
 		ProcessingTime: processingTime,
 		GasBaseFee:     baseFeeUsed,
+		GasRate:        gasRate,
 	}, nil
 }
 
@@ -138,4 +146,5 @@ type Block struct {
 	GasUsed        int           // gas used in the block
 	ProcessingTime time.Duration // block processing time
 	GasBaseFee     int           // gas base fee in the block
+	GasRate        float64       // gas rate in gas/s in the block
 }

--- a/driver/monitoring/network/block_metrics.go
+++ b/driver/monitoring/network/block_metrics.go
@@ -42,6 +42,12 @@ var (
 		Name:        "BlockGasBaseFee",
 		Description: "The base fee per gas used in a block",
 	}
+
+	// BlockGasRate is a metric capturing the Gas rate of each block.
+	BlockGasRate = monitoring.Metric[monitoring.Network, monitoring.Series[monitoring.BlockNumber, float64]]{
+		Name:        "BlockGasRate",
+		Description: "The gas rate in a block",
+	}
 )
 
 func init() {
@@ -54,6 +60,10 @@ func init() {
 	}
 
 	if err := monitoring.RegisterSource(BlockGasBaseFee, newGasBaseFeeSource); err != nil {
+		panic(fmt.Sprintf("failed to register metric source: %v", err))
+	}
+
+	if err := monitoring.RegisterSource(BlockGasRate, newGasRateSource); err != nil {
 		panic(fmt.Sprintf("failed to register metric source: %v", err))
 	}
 }
@@ -91,6 +101,14 @@ func NewGasBaseFeeSource(monitor *monitoring.Monitor) *BlockNetworkMetricSource[
 	return newBlockNetworkMetricsSource[int](monitor, f, BlockGasBaseFee)
 }
 
+// NewGasRateSource creates a metric capturing Gas used for each block of a network.
+func NewGasRateSource(monitor *monitoring.Monitor) *BlockNetworkMetricSource[float64] {
+	f := func(b monitoring.Block) float64 {
+		return b.GasRate
+	}
+	return newBlockNetworkMetricsSource[float64](monitor, f, BlockGasRate)
+}
+
 // newNumberOfTransactionsSource is the same as its public counterpart, it only returns the Source interface instead of the struct to be used in factories
 func newNumberOfTransactionsSource(monitor *monitoring.Monitor) monitoring.Source[monitoring.Network, monitoring.Series[monitoring.BlockNumber, int]] {
 	return NewNumberOfTransactionsSource(monitor)
@@ -104,6 +122,11 @@ func newGasUsedSource(monitor *monitoring.Monitor) monitoring.Source[monitoring.
 // newGasBaseFeeSource is the same as its public counterpart, it only returns the Source interface instead of the struct to be used in factories
 func newGasBaseFeeSource(monitor *monitoring.Monitor) monitoring.Source[monitoring.Network, monitoring.Series[monitoring.BlockNumber, int]] {
 	return NewGasBaseFeeSource(monitor)
+}
+
+// newGasRateSource is the same as its public counterpart, it only returns the Source interface instead of the struct to be used in factories
+func newGasRateSource(monitor *monitoring.Monitor) monitoring.Source[monitoring.Network, monitoring.Series[monitoring.BlockNumber, float64]] {
+	return NewGasRateSource(monitor)
 }
 
 // newBlockNodeMetricsSource creates a new data source periodically collecting data from the Node log

--- a/driver/monitoring/network/block_metrics.go
+++ b/driver/monitoring/network/block_metrics.go
@@ -36,6 +36,12 @@ var (
 		Name:        "BlockGasUsed",
 		Description: "The gas used in a block",
 	}
+
+	// BlockGasBaseFee is a metric capturing the Gas price in each block.
+	BlockGasBaseFee = monitoring.Metric[monitoring.Network, monitoring.Series[monitoring.BlockNumber, int]]{
+		Name:        "BlockGasBaseFee",
+		Description: "The base fee per gas used in a block",
+	}
 )
 
 func init() {
@@ -44,6 +50,10 @@ func init() {
 	}
 
 	if err := monitoring.RegisterSource(BlockGasUsed, newGasUsedSource); err != nil {
+		panic(fmt.Sprintf("failed to register metric source: %v", err))
+	}
+
+	if err := monitoring.RegisterSource(BlockGasBaseFee, newGasBaseFeeSource); err != nil {
 		panic(fmt.Sprintf("failed to register metric source: %v", err))
 	}
 }
@@ -73,6 +83,14 @@ func NewGasUsedSource(monitor *monitoring.Monitor) *BlockNetworkMetricSource[int
 	return newBlockNetworkMetricsSource[int](monitor, f, BlockGasUsed)
 }
 
+// NewGasBaseFeeSource creates a metric capturing Gas used for each block of a network.
+func NewGasBaseFeeSource(monitor *monitoring.Monitor) *BlockNetworkMetricSource[int] {
+	f := func(b monitoring.Block) int {
+		return b.GasBaseFee
+	}
+	return newBlockNetworkMetricsSource[int](monitor, f, BlockGasBaseFee)
+}
+
 // newNumberOfTransactionsSource is the same as its public counterpart, it only returns the Source interface instead of the struct to be used in factories
 func newNumberOfTransactionsSource(monitor *monitoring.Monitor) monitoring.Source[monitoring.Network, monitoring.Series[monitoring.BlockNumber, int]] {
 	return NewNumberOfTransactionsSource(monitor)
@@ -81,6 +99,11 @@ func newNumberOfTransactionsSource(monitor *monitoring.Monitor) monitoring.Sourc
 // newGasUsedSource is the same as its public counterpart, it only returns the Source interface instead of the struct to be used in factories
 func newGasUsedSource(monitor *monitoring.Monitor) monitoring.Source[monitoring.Network, monitoring.Series[monitoring.BlockNumber, int]] {
 	return NewGasUsedSource(monitor)
+}
+
+// newGasBaseFeeSource is the same as its public counterpart, it only returns the Source interface instead of the struct to be used in factories
+func newGasBaseFeeSource(monitor *monitoring.Monitor) monitoring.Source[monitoring.Network, monitoring.Series[monitoring.BlockNumber, int]] {
+	return NewGasBaseFeeSource(monitor)
 }
 
 // newBlockNodeMetricsSource creates a new data source periodically collecting data from the Node log

--- a/driver/monitoring/node_log_provider_test.go
+++ b/driver/monitoring/node_log_provider_test.go
@@ -110,6 +110,7 @@ type testBlockNodeListener struct {
 }
 
 func blockEqual(t *testing.T, node Node, got, want []Block) {
+	t.Helper()
 	if len(got) != len(want) {
 		t.Errorf("wrong blocks collected for Node %v: %v != %v", node, got, want)
 	}

--- a/driver/monitoring/testdata.go
+++ b/driver/monitoring/testdata.go
@@ -26,14 +26,14 @@ var (
 	Node2TestId = Node("B")
 	Node3TestId = Node("C")
 
-	Node1TestLog = "INFO [05-04|09:34:15.080] New block      index=1 id=2:1:247c79       gas_used=11 txs=10/0 age=7.392s t=\"711.334µs\" \n" +
-		"INFO [05-04|09:34:15.537] New block      index=2 id=3:1:3d6fb6       gas_used=22 txs=20/0 age=343.255ms t=1.579ms \n" +
-		"INFO [05-04|09:34:16.027] New block      index=3 id=3:4:9bb789       gas_used=33   txs=30/0 age=380.470ms t=1.540ms \n"
+	Node1TestLog = "INFO [05-04|09:34:15.080] New block      index=1 id=2:1:247c79       gas_used=11 txs=10/0 base_fee=1 gas_rate=1.23 age=7.392s t=\"711.334µs\" \n" +
+		"INFO [05-04|09:34:15.537] New block      index=2 id=3:1:3d6fb6       gas_used=22 txs=20/0 base_fee=2 gas_rate=2.31 age=343.255ms t=1.579ms \n" +
+		"INFO [05-04|09:34:16.027] New block      index=3 id=3:4:9bb789       gas_used=33 txs=30/0 base_fee=3 gas_rate=3.12 age=380.470ms t=1.540ms \n"
 
-	Node2TestLog = "INFO [05-04|09:34:16.512] New block      index=1 id=2:1:247c79       gas_used=11 txs=10/0 age=7.392s t=4.686ms \n" +
-		"INFO [05-04|09:34:17.003] New block      index=2 id=3:1:3d6fb6       gas_used=22 txs=20/0 age=343.255ms t=2.579ms \n"
+	Node2TestLog = "INFO [05-04|09:34:16.512] New block      index=1 id=2:1:247c79       gas_used=11 base_fee=1 gas_rate=3.4 txs=10/0 age=7.392s t=4.686ms \n" +
+		"INFO [05-04|09:34:17.003] New block      index=2 id=3:1:3d6fb6       gas_used=22 base_fee=2 gas_rate=5 txs=20/0 age=343.255ms t=2.579ms \n"
 
-	Node3TestLog = "INFO [05-04|09:38:15.080] New block      index=1 id=2:1:247c79       gas_used=11 txs=10/0 age=7.392s t=5.686ms \n"
+	Node3TestLog = "INFO [05-04|09:38:15.080] New block      index=1 id=2:1:247c79       gas_used=11 base_fee=1 gas_rate=2.34 txs=10/0 age=7.392s t=5.686ms \n"
 
 	year     = time.Now().Year()
 	time1, _ = time.Parse("2006-[01-02|15:04:05.000]", fmt.Sprintf("%d-[05-04|09:34:15.080]", year))
@@ -50,14 +50,14 @@ var (
 	dur5, _ = time.ParseDuration("2.579ms")
 	dur6, _ = time.ParseDuration("5.686ms")
 
-	block1 = Block{Height: 1, Time: time1, Txs: 10, GasUsed: 11, ProcessingTime: dur1}
-	block2 = Block{Height: 2, Time: time2, Txs: 20, GasUsed: 22, ProcessingTime: dur2}
-	block3 = Block{Height: 3, Time: time3, Txs: 30, GasUsed: 33, ProcessingTime: dur3}
+	block1 = Block{Height: 1, Time: time1, Txs: 10, GasUsed: 11, ProcessingTime: dur1, GasBaseFee: 1, GasRate: 1.23}
+	block2 = Block{Height: 2, Time: time2, Txs: 20, GasUsed: 22, ProcessingTime: dur2, GasBaseFee: 2, GasRate: 2.31}
+	block3 = Block{Height: 3, Time: time3, Txs: 30, GasUsed: 33, ProcessingTime: dur3, GasBaseFee: 3, GasRate: 3.12}
 
-	block4 = Block{Height: 1, Time: time4, Txs: 10, GasUsed: 11, ProcessingTime: dur4}
-	block5 = Block{Height: 2, Time: time5, Txs: 20, GasUsed: 22, ProcessingTime: dur5}
+	block4 = Block{Height: 1, Time: time4, Txs: 10, GasUsed: 11, ProcessingTime: dur4, GasBaseFee: 1, GasRate: 3.4}
+	block5 = Block{Height: 2, Time: time5, Txs: 20, GasUsed: 22, ProcessingTime: dur5, GasBaseFee: 2, GasRate: 5}
 
-	block6 = Block{Height: 1, Time: time6, Txs: 10, GasUsed: 11, ProcessingTime: dur6}
+	block6 = Block{Height: 1, Time: time6, Txs: 10, GasUsed: 11, ProcessingTime: dur6, GasBaseFee: 1, GasRate: 2.34}
 
 	NodeBlockTestData = map[Node][]Block{
 		Node1TestId: {block1, block2, block3},

--- a/driver/parser/parser.go
+++ b/driver/parser/parser.go
@@ -27,7 +27,7 @@ import (
 const (
 	DefaultInstance = 1
 	// MaxBlockGas, MaxEpochGas defaults borrowed from example-genesis.json
-	DefaultMaxBlockGas = 20_500_000
+	DefaultMaxBlockGas = 20_500_000_000
 	DefaultMaxEpochGas = 1_500_000_000_000
 )
 

--- a/driver/parser/parser.go
+++ b/driver/parser/parser.go
@@ -27,7 +27,7 @@ import (
 const (
 	DefaultInstance = 1
 	// MaxBlockGas, MaxEpochGas defaults borrowed from example-genesis.json
-	DefaultMaxBlockGas = 20_500_000_000
+	DefaultMaxBlockGas = 20_500_000
 	DefaultMaxEpochGas = 1_500_000_000_000
 )
 

--- a/scripts/run_sonic_privatenet.sh
+++ b/scripts/run_sonic_privatenet.sh
@@ -70,4 +70,5 @@ fi
     --nat=extip:${external_ip} \
     --metrics \
     --metrics.expensive \
-    --config config.toml
+    --config config.toml \
+    --datadir.minfreedisk 0


### PR DESCRIPTION
This PR adds tracking support for two new metrics:
- the gas `base-fee` prices on a per-block level, measured in `wei/gas`
- the gas throughput on a per-block level, measured in `gas/s` 

Example:
![image](https://github.com/user-attachments/assets/db581d55-56c0-4da6-b955-950a6abd8091)
