### PR TITLE
puts network consistency check before shutdown

### DIFF
--- a/driver/checking/block_height.go
+++ b/driver/checking/block_height.go
@@ -30,6 +30,7 @@ type BlockHeightChecker struct {
 
 func (*BlockHeightChecker) Check(net driver.Network) error {
 	nodes := net.GetActiveNodes()
+	fmt.Printf("checking block heights for %d nodes\n", len(nodes))
 	heights := make([]int64, len(nodes))
 	maxHeight := int64(0)
 	for i, n := range nodes {

--- a/driver/checking/blocks_hashes.go
+++ b/driver/checking/blocks_hashes.go
@@ -31,6 +31,7 @@ type BlocksHashesChecker struct {
 
 func (*BlocksHashesChecker) Check(net driver.Network) (err error) {
 	nodes := net.GetActiveNodes()
+	fmt.Printf("checking hashes for %d nodes\n", len(nodes))
 	rpcClients := make([]rpc.RpcClient, len(nodes))
 	for i, n := range nodes {
 		rpcClients[i], err = n.DialRpc()

--- a/driver/executor/executor_test.go
+++ b/driver/executor/executor_test.go
@@ -36,7 +36,7 @@ func TestExecutor_RunEmptyScenario(t *testing.T) {
 		Duration: 10,
 	}
 
-	if err := Run(clock, net, &scenario, ""); err != nil {
+	if err := Run(clock, net, &scenario, true); err != nil {
 		t.Errorf("failed to run empty scenario: %v", err)
 	}
 	want := Seconds(10)
@@ -70,7 +70,7 @@ func TestExecutor_RunSingleNodeScenario(t *testing.T) {
 		node.EXPECT().Cleanup(),
 	)
 
-	if err := Run(clock, net, &scenario, ""); err != nil {
+	if err := Run(clock, net, &scenario, true); err != nil {
 		t.Errorf("failed to run scenario: %v", err)
 	}
 	want := Seconds(10)
@@ -112,7 +112,7 @@ func TestExecutor_RunMultipleNodeScenario(t *testing.T) {
 		node2.EXPECT().Cleanup(),
 	)
 
-	if err := Run(clock, net, &scenario, ""); err != nil {
+	if err := Run(clock, net, &scenario, true); err != nil {
 		t.Errorf("failed to run scenario: %v", err)
 	}
 	want := Seconds(10)
@@ -145,7 +145,7 @@ func TestExecutor_RunSingleApplicationScenario(t *testing.T) {
 	app.EXPECT().Start()
 	app.EXPECT().Stop()
 
-	if err := Run(clock, net, &scenario, ""); err != nil {
+	if err := Run(clock, net, &scenario, true); err != nil {
 		t.Errorf("failed to run scenario: %v", err)
 	}
 	want := Seconds(10)
@@ -183,7 +183,7 @@ func TestExecutor_RunMultipleApplicationScenario(t *testing.T) {
 	app2.EXPECT().Start()
 	app2.EXPECT().Stop()
 
-	if err := Run(clock, net, &scenario, ""); err != nil {
+	if err := Run(clock, net, &scenario, true); err != nil {
 		t.Errorf("failed to run scenario: %v", err)
 	}
 	want := Seconds(10)
@@ -215,7 +215,7 @@ func TestExecutor_TestUserAbort(t *testing.T) {
 		syscall.Kill(syscall.Getpid(), syscall.SIGINT)
 	}).Return(node, nil)
 
-	if err := Run(clock, net, &scenario, ""); err == nil {
+	if err := Run(clock, net, &scenario, true); err == nil {
 		t.Errorf("a user interrupt error should be reported")
 	}
 	want := Seconds(1)

--- a/driver/norma/run.go
+++ b/driver/norma/run.go
@@ -24,8 +24,6 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/Fantom-foundation/Norma/driver/checking"
-
 	"github.com/Fantom-foundation/Norma/analysis/report"
 	"github.com/Fantom-foundation/Norma/driver"
 	"github.com/Fantom-foundation/Norma/driver/executor"
@@ -249,22 +247,11 @@ func runScenario(path, outputDir, label string, keepPrometheusRunning, skipCheck
 	fmt.Printf("Running '%s' ...\n", path)
 	logger := startProgressLogger(monitor, net)
 	defer logger.shutdown()
-	err = executor.Run(clock, net, &scenario, outputDir)
+	err = executor.Run(clock, net, &scenario, skipChecks)
 	if err != nil {
 		return err
 	}
 	fmt.Printf("Execution completed successfully!\n")
-
-	if !skipChecks {
-		fmt.Printf("Checking network consistency ...\n")
-		err = checking.CheckNetworkConsistency(net)
-		if err != nil {
-			return fmt.Errorf("checking the network consistency failed: %v", err)
-		}
-		fmt.Printf("Network checks succeed.\n")
-	} else {
-		fmt.Printf("Network checks skipped\n")
-	}
 
 	return nil
 }

--- a/scenarios/test/nodes_net_consistency.yml
+++ b/scenarios/test/nodes_net_consistency.yml
@@ -1,0 +1,71 @@
+# This scenario simulates a network with the various number of nodes.
+# It starts and stopes nodes at different times.
+# It makes sure that many nodes run till the end of the scenario
+# to allow for the consistency check to see many nodes.
+# The nodes include validators and non-validator nodes.
+# It deploys one application and sends a decent number of transactions.
+
+# The name of the scenario
+name: Network Consistency
+
+# The duration of the scenario's runtime, in seconds.
+duration: 240
+
+# The number of validator nodes in the network.
+num_validators: 2
+
+# The network scenario to exercise. 
+nodes:
+  # Change the number of nodes during the scenario.
+  - name: validator-A
+    start: 20
+    end: 120
+    instances: 2
+    features: [ validator ]
+
+  - name: validator-B
+    start: 40
+    end: 80
+    instances: 1
+    features: [ validator ]
+
+  - name: observer-A
+    start: 90
+    end: 180
+    instances: 2
+
+  - name: observer-B
+    start: 100    # This node will run till the end of the scenario
+    instances: 1
+
+  - name: observer-C
+    start: 190      # This node will run till the end of the scenario
+    instances: 2
+
+  - name: validator-C
+    start: 140         # This node will run till the end of the scenario
+    instances: 2
+    features: [ validator ]
+
+
+# In the network, there is a single application producing a constant load.
+applications:
+  - name: counter
+    type: counter
+    users: 20           # number of users using the app
+    rate:
+      constant: 10     # Tx/s
+
+  - name: erc20
+    type: erc20
+    start: 60
+    users: 20           # number of users using the app
+    rate:
+      constant: 10     # Tx/s
+
+  - name: uniswap
+    type: uniswap
+    start: 80
+    users: 20           # number of users using the app
+    rate:
+      constant: 10     # Tx/s

--- a/scenarios/test/nodes_net_consistency.yml
+++ b/scenarios/test/nodes_net_consistency.yml
@@ -21,13 +21,15 @@ nodes:
     start: 20
     end: 120
     instances: 2
-    features: [ validator ]
+    client:
+      type: validator
 
   - name: validator-B
     start: 40
     end: 80
     instances: 1
-    features: [ validator ]
+    client:
+      type: validator
 
   - name: observer-A
     start: 90
@@ -45,7 +47,8 @@ nodes:
   - name: validator-C
     start: 140         # This node will run till the end of the scenario
     instances: 2
-    features: [ validator ]
+    client:
+      type: validator
 
 
 # In the network, there is a single application producing a constant load.


### PR DESCRIPTION
This PR updates when network consistency is executed. 

It used to be executed at the end of scenario, but unfortunetly at that moment all dyanmic nodes are alreay shutdown. The only nodes still running are static validators. 

This PR schedules consistency check as an event just before the end (1s) of execution. At this moment all nodes runnign till the end of experiment, are still active. 

This change still misses nodes that were halted before end of scenario, we could consider adding an extra configuration to schedule the consistency check at any time.  