### PR TITLE
generates uniq addresses for multiple applications

### DIFF
--- a/load/app/account.go
+++ b/load/app/account.go
@@ -36,8 +36,9 @@ import (
 // Any factory using the same mnemonic, feederId and appId produce the same sequence of accounts,
 // which can be used to reuse existing accounts from previous runs.
 type AccountFactory struct {
-	chainID     *big.Int
-	numAccounts int64
+	chainID         *big.Int
+	numAccounts     int64
+	feederId, appId uint32
 }
 
 // NewAccountFactory creates a new AccountFactory, generating accounts for given feeder and app.
@@ -46,6 +47,8 @@ func NewAccountFactory(chainID *big.Int, feederId, appId uint32) (*AccountFactor
 	return &AccountFactory{
 		chainID:     chainID,
 		numAccounts: 0,
+		feederId:    feederId,
+		appId:       appId,
 	}, nil
 }
 
@@ -54,6 +57,8 @@ func (f *AccountFactory) CreateAccount(rpcClient rpc.RpcClient) (*Account, error
 	id := atomic.AddInt64(&f.numAccounts, 1)
 	d := make([]byte, 32)
 	binary.BigEndian.PutUint64(d[:24], uint64(id))
+	binary.BigEndian.PutUint32(d[24:], f.feederId)
+	binary.BigEndian.PutUint32(d[28:], f.appId)
 	privateKey, err := crypto.ToECDSA(d)
 	if err != nil {
 		return nil, err

--- a/load/app/account_test.go
+++ b/load/app/account_test.go
@@ -1,0 +1,40 @@
+package app
+
+import (
+	"github.com/Fantom-foundation/Norma/driver/rpc"
+	"github.com/ethereum/go-ethereum/common"
+	"go.uber.org/mock/gomock"
+	"math/big"
+	"testing"
+)
+
+func TestAccount_CreateAccount_AccountsUniq(t *testing.T) {
+	chainId := big.NewInt(0xFA)
+	const loops = 100
+
+	ctrl := gomock.NewController(t)
+	rpcClient := rpc.NewMockRpcClient(ctrl)
+	rpcClient.EXPECT().NonceAt(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(uint64(0), nil)
+
+	accounts := make(map[common.Address]struct{}, loops)
+	for i := 0; i < loops; i++ {
+		gen, err := NewAccountFactory(chainId, 0, uint32(i))
+		if err != nil {
+			t.Fatalf("cannot create account factory: %v", err)
+		}
+
+		for j := 0; j < loops; j++ {
+			account, err := gen.CreateAccount(rpcClient)
+			if err != nil {
+				t.Fatalf("cannot create account: %v", err)
+			}
+
+			if _, ok := accounts[account.address]; ok {
+				t.Errorf("account address %v is not unique", account.address)
+			}
+
+			accounts[account.address] = struct{}{}
+		}
+	}
+
+}


### PR DESCRIPTION
This PR fixes address factory to generate uniq addresses when more factorires is used. 

The factories had application ID as an argument, but this ID was not used. It caused that non-unique addresses were generated when more applications were deployed in an experiment. 

This PR fixes this problem by including application ID and feed ID in the address. 