### PR TITLE
Increase get receipt timeout

### DIFF
--- a/load/app/context.go
+++ b/load/app/context.go
@@ -221,7 +221,7 @@ func GetReceipt(txHash common.Hash, rpcClient rpc.RpcClient) (*types.Receipt, er
 	const maxDelay = 100 * time.Millisecond
 	begin := time.Now()
 	delay := time.Millisecond
-	for time.Since(begin) < 10*time.Second {
+	for time.Since(begin) < 20*time.Second {
 		receipt, err := rpcClient.TransactionReceipt(context.Background(), txHash)
 		if errors.Is(err, ethereum.NotFound) {
 			time.Sleep(delay)


### PR DESCRIPTION
Currently, the test `TestLocalNetwork_Num_Validators_Started` failed sporadically with the following symptom:
```
17:27:18  === NAME  TestLocalNetwork_Num_Validators_Started/num_validators=2
17:27:18      local_test.go:384: failed to create new local network: failed to create app context; failed to deploy helper contract: failed to get receipt: failed to get transaction receipt: timeout
```

Increasing timeout from 10 seconds to 20 seconds remove this behavior consistently.