### PR TITLE
Add support for adding round-trip-time latency in scenarios

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,6 +50,10 @@ RUN --mount=type=cache,target=/root/.cache/go-build make normatool
 # > docker run -e VALIDATOR_NUMBER=2 -e VALIDATORS_COUNT=5 -i -t sonic
 #
 FROM debian:bookworm
+
+RUN apt-get update && \
+    apt-get install iproute2 iputils-ping -y
+
 COPY --from=client-build /client/build/sonicd /client/build/sonictool ./
 COPY --from=client-build /norma/build/normatool ./
 

--- a/driver/docker/docker.go
+++ b/driver/docker/docker.go
@@ -170,6 +170,7 @@ func (c *Client) Start(config *ContainerConfig) (*Container, error) {
 	}, &container.HostConfig{
 		PortBindings: portMapping,
 		Init:         &init,
+		CapAdd:       []string{"NET_ADMIN"},
 	}, nil, nil, "")
 	if err != nil {
 		return nil, err

--- a/driver/network.go
+++ b/driver/network.go
@@ -17,6 +17,8 @@
 package driver
 
 import (
+	"time"
+
 	"github.com/Fantom-foundation/Norma/driver/parser"
 	"github.com/Fantom-foundation/Norma/driver/rpc"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -73,6 +75,8 @@ type NetworkConfig struct {
 	MaxBlockGas uint64
 	// MaxEpochGas is the maximum gas limit for an epoch in the network.
 	MaxEpochGas uint64
+	// RoundTripTime is the average round trip time between nodes in the network.
+	RoundTripTime time.Duration
 }
 
 // NetworkListener can be registered to networks to get callbacks whenever there

--- a/driver/network/local/local_test.go
+++ b/driver/network/local/local_test.go
@@ -77,13 +77,13 @@ func TestLocalNetwork_CanStartNodesAndShutThemDown(t *testing.T) {
 
 func TestLocalNetwork_CanEnforceNetworkLatency(t *testing.T) {
 	t.Parallel()
-	for _, latency := range []time.Duration{0, 100 * time.Millisecond, 200 * time.Millisecond} {
-		latency := latency
-		t.Run(fmt.Sprintf("rtt=%v", latency), func(t *testing.T) {
+	for _, rtt := range []time.Duration{0, 100 * time.Millisecond, 200 * time.Millisecond} {
+		rtt := rtt
+		t.Run(fmt.Sprintf("rtt=%v", rtt), func(t *testing.T) {
 			t.Parallel()
 			config := driver.NetworkConfig{
 				NumberOfValidators: 2,
-				RoundTripTime:      latency,
+				RoundTripTime:      rtt,
 			}
 			net, err := NewLocalNetwork(&config)
 			if err != nil {
@@ -98,15 +98,15 @@ func TestLocalNetwork_CanEnforceNetworkLatency(t *testing.T) {
 			if got, want := len(nodes), 2; got != want {
 				t.Fatalf("invalid number of active nodes, got %d, want %d", got, want)
 			}
-			delay, err := nodes[0].(*node.OperaNode).GetNetworkDelayTo(nodes[1].Hostname())
+			got, err := nodes[0].(*node.OperaNode).GetRoundTripTime(nodes[1].Hostname())
 			if err != nil {
 				t.Errorf("failed to measure network delay: %v", err)
 			}
-			if delay < latency-10*time.Millisecond {
-				t.Errorf("network latency is too low: %v < %v", delay, latency)
+			if got < rtt-10*time.Millisecond {
+				t.Errorf("network RTT is too low: %v < %v", got, rtt)
 			}
-			if delay > latency+10*time.Millisecond {
-				t.Errorf("network latency is too high: %v > %v", delay, latency)
+			if got > rtt+10*time.Millisecond {
+				t.Errorf("network RTT is too high: %v > %v", got, rtt)
 			}
 		})
 	}

--- a/driver/node/opera.go
+++ b/driver/node/opera.go
@@ -251,8 +251,8 @@ func (n *OperaNode) Kill() error {
 	return n.container.SendSignal(docker.SigKill)
 }
 
-// GetNetworkDelayTo returns the median network delay to the given host.
-func (n *OperaNode) GetNetworkDelayTo(host string) (time.Duration, error) {
+// GetRoundTripTime returns the median network round-trip time to the given host.
+func (n *OperaNode) GetRoundTripTime(host string) (time.Duration, error) {
 	output, err := n.container.Exec([]string{"ping", "-c", "5", host})
 	if err != nil {
 		return 0, err

--- a/driver/node/opera.go
+++ b/driver/node/opera.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io"
 	"regexp"
+	"slices"
 	"time"
 
 	rpcdriver "github.com/Fantom-foundation/Norma/driver/rpc"
@@ -120,6 +121,7 @@ func StartOperaDockerNode(client *docker.Client, dn *docker.Network, config *Ope
 				"VALIDATORS_COUNT": fmt.Sprintf("%d", config.NetworkConfig.NumberOfValidators),
 				"MAX_BLOCK_GAS":    fmt.Sprintf("%d", config.NetworkConfig.MaxBlockGas),
 				"MAX_EPOCH_GAS":    fmt.Sprintf("%d", config.NetworkConfig.MaxEpochGas),
+				"NETWORK_LATENCY":  fmt.Sprintf("%v", config.NetworkConfig.RoundTripTime/2),
 			},
 			Network: dn,
 		})
@@ -247,4 +249,25 @@ func (n *OperaNode) RemovePeer(id driver.NodeID) error {
 // Kill sends a SigKill singal to node.
 func (n *OperaNode) Kill() error {
 	return n.container.SendSignal(docker.SigKill)
+}
+
+// GetNetworkDelayTo returns the median network delay to the given host.
+func (n *OperaNode) GetNetworkDelayTo(host string) (time.Duration, error) {
+	output, err := n.container.Exec([]string{"ping", "-c", "5", host})
+	if err != nil {
+		return 0, err
+	}
+	regex := regexp.MustCompile("time=([0-9.]+) ms")
+	matches := regex.FindAllStringSubmatch(string(output), -1)
+
+	durations := make([]time.Duration, 0, len(matches))
+	for _, match := range matches {
+		duration, err := time.ParseDuration(match[1] + "ms")
+		if err != nil {
+			return 0, err
+		}
+		durations = append(durations, duration)
+	}
+	slices.Sort(durations)
+	return durations[len(durations)/2], nil
 }

--- a/driver/norma/run.go
+++ b/driver/norma/run.go
@@ -173,11 +173,13 @@ func runScenario(path, outputDir, label string, keepPrometheusRunning, skipCheck
 	fmt.Printf("Creating network with: \n")
 	fmt.Printf("    Network max block gas: %d\n", scenario.GetMaxBlockGas())
 	fmt.Printf("    Network max epoch gas: %d\n", scenario.GetMaxEpochGas())
+	fmt.Printf("    Network RoundTripTime: %v\n", scenario.GetRoundTripTime())
 
 	net, err := local.NewLocalNetwork(&driver.NetworkConfig{
 		NumberOfValidators: scenario.GetNumValidators(),
 		MaxBlockGas:        scenario.GetMaxBlockGas(),
 		MaxEpochGas:        scenario.GetMaxEpochGas(),
+		RoundTripTime:      scenario.GetRoundTripTime(),
 	})
 	if err != nil {
 		return err

--- a/driver/parser/check.go
+++ b/driver/parser/check.go
@@ -41,6 +41,9 @@ func (s *Scenario) Check() error {
 	if err := s.checkValidatorConstraints(); err != nil {
 		errs = append(errs, err)
 	}
+	if s.RoundTripTime != nil && *s.RoundTripTime < 0 {
+		errs = append(errs, fmt.Errorf("round trip time must be >= 0, is %v", *s.RoundTripTime))
+	}
 
 	names := map[string]bool{}
 	for _, node := range s.Nodes {

--- a/driver/parser/check_test.go
+++ b/driver/parser/check_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestTimeRange_UnconstraintInputIsAccepted(t *testing.T) {
@@ -388,6 +389,15 @@ func TestScenario_NegativeNumberOfValidatorsIsDetected(t *testing.T) {
 	*scenario.NumValidators = -5
 	if err := scenario.Check(); err == nil || !strings.Contains(err.Error(), "invalid number of validators: -5 < 1") {
 		t.Errorf("negative number of validators was not detected")
+	}
+}
+
+func TestScenario_NegativeRoundTripTimeIsDetected(t *testing.T) {
+	scenario := Scenario{Name: "Test"}
+	scenario.RoundTripTime = new(time.Duration)
+	*scenario.RoundTripTime = -5
+	if err := scenario.Check(); err == nil || !strings.Contains(err.Error(), "round trip time must be >= 0") {
+		t.Errorf("negative round-trip time was not detected")
 	}
 }
 

--- a/driver/parser/parser.go
+++ b/driver/parser/parser.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"io"
 	"os"
+	"time"
 
 	"gopkg.in/yaml.v3"
 )
@@ -36,11 +37,12 @@ const (
 type Scenario struct {
 	Name             string
 	Duration         float32
-	NumValidators    *int          `yaml:"num_validators,omitempty"` // nil == 1
-	GenesisGasLimits GasLimits     `yaml:"genesis_gas_limit,omitempty"`
-	Nodes            []Node        `yaml:",omitempty"`
-	Applications     []Application `yaml:",omitempty"`
-	Cheats           []Cheat       `yaml:",omitempty"`
+	NumValidators    *int           `yaml:"num_validators,omitempty"`  // nil == 1
+	RoundTripTime    *time.Duration `yaml:"round_trip_time,omitempty"` // nil == 0
+	GenesisGasLimits GasLimits      `yaml:"genesis_gas_limit,omitempty"`
+	Nodes            []Node         `yaml:",omitempty"`
+	Applications     []Application  `yaml:",omitempty"`
+	Cheats           []Cheat        `yaml:",omitempty"`
 }
 
 // GasLimits is a configuration group for gas limit rules
@@ -72,6 +74,13 @@ func (s *Scenario) GetNumValidators() int {
 		return *s.NumValidators
 	}
 	return 1
+}
+
+func (s *Scenario) GetRoundTripTime() time.Duration {
+	if s.RoundTripTime != nil {
+		return *s.RoundTripTime
+	}
+	return 0
 }
 
 // Node is a configuration for a group of nodes with similar properties.

--- a/scenarios/test/baseline_check.yml
+++ b/scenarios/test/baseline_check.yml
@@ -6,6 +6,7 @@ name: Baseline Check
 # The duration of the scenario's runtime, in seconds.
 duration: 60
 num_validators: 2
+round_trip_time: "200ms"
 
 # In the network there is a single application producing constant load.
 applications:

--- a/scripts/run_sonic_privatenet.sh
+++ b/scripts/run_sonic_privatenet.sh
@@ -60,6 +60,18 @@ else
   echo DoublesignProtection = 5000000000 >> config.toml
 fi
 
+# Add network latency between nodes. The following command delays
+# each out-going package by the given latency. To get a given
+# round-trip time, the one-way latency has to be half of it.
+# To check, run `docker exec <src-container-id> ping <dst-container-id>` on host.
+echo "NETWORK_LATENCY=${NETWORK_LATENCY}"
+if [[ -n "${NETWORK_LATENCY}" ]]; then
+  echo "Adding network latency .."
+  tc qdisc add dev eth0 root netem delay $NETWORK_LATENCY
+  tc qdisc add dev eth1 root netem delay $NETWORK_LATENCY
+fi
+
+
 # Start sonic as part of a fake net with RPC service.
 ./sonicd \
     --datadir=${datadir} \


### PR DESCRIPTION
This PR adds support for a new top-level `round_trip_time` configuration option is added

With the `round_trip_time` an arbitrary network latency duration can be added for any message being exchanged between nodes running in docker containers. The delay is introduced using the `tc` command in every container to delay out-going messages by half the defined round-trip-time.